### PR TITLE
Add algorithm include to fix building on MSVC2019

### DIFF
--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -26,6 +26,8 @@
 #include <OpenThreads/ScopedLock>
 #include <OpenThreads/Mutex>
 
+#include <algorithm>
+
 #ifndef GL_TEXTURE_WRAP_R
 #define GL_TEXTURE_WRAP_R                 0x8072
 #endif


### PR DESCRIPTION
The errors fixed are;
```
src\osg\Texture.cpp(416): error C2039: 'max': is not a member of 'std'
src\osg\Texture.cpp(416): error C3861: 'max': identifier not found
```