### PR TITLE
Support BC4- and BC5-compressed DDS images

### DIFF
--- a/src/osg/Image.cpp
+++ b/src/osg/Image.cpp
@@ -1826,13 +1826,14 @@ void Image::flipVertical()
     unsigned int rowStep = getRowStepInBytes();
 
     const bool dxtc(dxtc_tool::isDXTC(_pixelFormat));
+    const bool rgtc(dxtc_tool::isRGTC(_pixelFormat));
     if (_mipmapData.empty())
     {
         // no mipmaps,
         // so we can safely handle 3d textures
         for(int r=0;r<_r;++r)
         {
-            if (dxtc)
+            if (dxtc || rgtc)
             {
                 if (!dxtc_tool::VerticalFlip(_s,_t,_pixelFormat,data(0,0,r)))
                 {
@@ -1852,7 +1853,7 @@ void Image::flipVertical()
     }
     else if (_r==1)
     {
-        if (dxtc)
+        if (dxtc || rgtc)
         {
             if (!dxtc_tool::VerticalFlip(_s,_t,_pixelFormat,_data))
             {
@@ -1879,7 +1880,7 @@ void Image::flipVertical()
             t >>= 1;
             if (s==0) s=1;
             if (t==0) t=1;
-            if (dxtc)
+            if (dxtc || rgtc)
             {
                 if (!dxtc_tool::VerticalFlip(s,t,_pixelFormat,_data+_mipmapData[i]))
                 {

--- a/src/osg/dxtctool.cpp
+++ b/src/osg/dxtctool.cpp
@@ -14,6 +14,8 @@ namespace dxtc_tool {
     const size_t dxtc_pixels::BSIZE_DXT1 = 8;
     const size_t dxtc_pixels::BSIZE_DXT3 = 16;
     const size_t dxtc_pixels::BSIZE_DXT5 = 16;
+    const size_t dxtc_pixels::BSIZE_RGTC1 = 8;
+    const size_t dxtc_pixels::BSIZE_RGTC2 = 16;
     const size_t dxtc_pixels::BSIZE_ALPHA_DXT3 = 8;
     const size_t dxtc_pixels::BSIZE_ALPHA_DXT5 = 8;
 
@@ -68,6 +70,10 @@ bool dxtc_pixels::VFlip() const
         VFlip_DXT3();
     else if (DXT5())
         VFlip_DXT5();
+    else if (RGTC1())
+        VFlip_RGTC1();
+    else if (RGTC2())
+        VFlip_RGTC2();
     else
         return false; // We should never get there
 
@@ -155,6 +161,48 @@ void dxtc_pixels::VFlip_DXT5() const
             }
 }
 
+void dxtc_pixels::VFlip_RGTC1() const
+{
+    if (m_Height == 2)
+        for (size_t j = 0; j < (m_Width + 3) / 4; ++j) {
+            BVF_Alpha_DXT5_H2(((dxtc_int8 * ) m_pPixels) + (j * BSIZE_RGTC1));
+        }
+
+    if (m_Height == 4)
+        for (size_t j = 0; j < (m_Width + 3) / 4; ++j) {
+            BVF_Alpha_DXT5_H4(((dxtc_int8 * ) m_pPixels) + (j * BSIZE_RGTC1));
+        }
+
+    if (m_Height > 4)
+        for (size_t i = 0; i < ((m_Height + 7) / 8); ++i)
+            for (size_t j = 0; j < (m_Width + 3) / 4; ++j) {
+                const size_t TargetRow = ((m_Height + 3) / 4) - (i + 1);
+                BVF_Alpha_DXT5(GetBlock(i, j, BSIZE_RGTC1), GetBlock(TargetRow, j, BSIZE_RGTC1));
+            }
+}
+
+void dxtc_pixels::VFlip_RGTC2() const
+{
+    if (m_Height == 2)
+        for (size_t j = 0; j < (m_Width + 3) / 4; ++j) {
+            BVF_Alpha_DXT5_H2(((dxtc_int8 * ) m_pPixels) + (j * BSIZE_RGTC2));
+            BVF_Alpha_DXT5_H2(((dxtc_int8 * ) m_pPixels) + (j * BSIZE_RGTC2) + BSIZE_RGTC2 / 2);
+        }
+
+    if (m_Height == 4)
+        for (size_t j = 0; j < (m_Width + 3) / 4; ++j) {
+            BVF_Alpha_DXT5_H4(((dxtc_int8 * ) m_pPixels) + (j * BSIZE_RGTC2));
+            BVF_Alpha_DXT5_H4(((dxtc_int8 * ) m_pPixels) + (j * BSIZE_RGTC2) + BSIZE_RGTC2 / 2);
+        }
+
+    if (m_Height > 4)
+        for (size_t i = 0; i < ((m_Height + 7) / 8); ++i)
+            for (size_t j = 0; j < (m_Width + 3) / 4; ++j) {
+                const size_t TargetRow = ((m_Height + 3) / 4) - (i + 1);
+                BVF_Color_RGTC2(GetBlock(i, j, BSIZE_RGTC2), GetBlock(TargetRow, j, BSIZE_RGTC2));
+            }
+}
+
 //
 // Structure of a DXT-1 compressed texture block
 // see page "Opaque and 1-Bit Alpha Textures (Direct3D 9)" on http://msdn.microsoft.com
@@ -182,6 +230,18 @@ struct DXT5TexelsBlock
     unsigned short color_0;     // colors at their
     unsigned short color_1;     // extreme
     unsigned int   texels4x4;   // interpolated colors (2 bits per texel)
+};
+
+struct RGTC1TexelsBlock
+{
+    unsigned char color_0;      // colors at their
+    unsigned char color_1;      // extreme
+    unsigned char color3[6];    // color index values (3 bits per texel)
+};
+
+struct RGTC2TexelsBlock
+{
+    RGTC1TexelsBlock channels[2];
 };
 
 bool isCompressedImageTranslucent(size_t width, size_t height, GLenum format, void * imageData)
@@ -475,6 +535,7 @@ bool CompressedImageGetColor(unsigned char color[4], unsigned int s, unsigned in
         }
         break;
     }
+    // TODO: add RGTC support
     default:
         return false;
     }
@@ -579,6 +640,7 @@ void compressedBlockOrientationConversion(const GLenum format, const unsigned ch
         }
         break;
     }
+    // TODO: add RGTC support
     default:
         return;
     }//switch

--- a/src/osgPlugins/dds/ReaderWriterDDS.cpp
+++ b/src/osgPlugins/dds/ReaderWriterDDS.cpp
@@ -258,7 +258,11 @@ struct DXT1TexelsBlock
 * FOURCC codes for 3dc compressed-texture pixel formats
 */
 #define FOURCC_ATI1  (MAKEFOURCC('A','T','I','1'))
+#define FOURCC_BC4U  (MAKEFOURCC('B','C','4','U'))
+#define FOURCC_BC4S  (MAKEFOURCC('B','C','4','S'))
 #define FOURCC_ATI2  (MAKEFOURCC('A','T','I','2'))
+#define FOURCC_BC5U  (MAKEFOURCC('B','C','5','U'))
+#define FOURCC_BC5S  (MAKEFOURCC('B','C','5','S'))
 
 /*
 * FOURCC codes for DX10 files
@@ -517,10 +521,30 @@ osg::Image* ReadDDSFile(std::istream& _istream, bool flipDDSRead)
             internalFormat = GL_COMPRESSED_RED_RGTC1_EXT;
             pixelFormat    = GL_COMPRESSED_RED_RGTC1_EXT;
             break;
+        case FOURCC_BC4U:
+            OSG_INFO << "ReadDDSFile info : format = BC4U" << std::endl;
+            internalFormat = GL_COMPRESSED_RED_RGTC1_EXT;
+            pixelFormat    = GL_COMPRESSED_RED_RGTC1_EXT;
+            break;
+        case FOURCC_BC4S:
+            OSG_INFO << "ReadDDSFile info : format = BC4S" << std::endl;
+            internalFormat = GL_COMPRESSED_SIGNED_RED_RGTC1_EXT;
+            pixelFormat    = GL_COMPRESSED_SIGNED_RED_RGTC1_EXT;
+            break;
         case FOURCC_ATI2:
             OSG_INFO << "ReadDDSFile info : format = ATI2" << std::endl;
             internalFormat = GL_COMPRESSED_RED_GREEN_RGTC2_EXT;
             pixelFormat    = GL_COMPRESSED_RED_GREEN_RGTC2_EXT;
+            break;
+        case FOURCC_BC5U:
+            OSG_INFO << "ReadDDSFile info : format = BC5U" << std::endl;
+            internalFormat = GL_COMPRESSED_RED_GREEN_RGTC2_EXT;
+            pixelFormat    = GL_COMPRESSED_RED_GREEN_RGTC2_EXT;
+            break;
+        case FOURCC_BC5S:
+            OSG_INFO << "ReadDDSFile info : format = BC5S" << std::endl;
+            internalFormat = GL_COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT;
+            pixelFormat    = GL_COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT;
             break;
         case 0x00000024: // A16B16G16R16
             OSG_INFO << "ReadDDSFile info : format = A16B16G16R16" << std::endl;
@@ -768,6 +792,26 @@ osg::Image* ReadDDSFile(std::istream& _istream, bool flipDDSRead)
                     internalFormat = GL_R16I;
                     pixelFormat    = GL_RED;
                     dataType       = GL_SHORT;
+                    break;
+
+                case OSG_DXGI_FORMAT_BC4_UNORM:
+                    internalFormat = GL_COMPRESSED_RED_RGTC1_EXT;
+                    pixelFormat    = GL_COMPRESSED_RED_RGTC1_EXT;
+                    break;
+
+                case OSG_DXGI_FORMAT_BC4_SNORM:
+                    internalFormat = GL_COMPRESSED_SIGNED_RED_RGTC1_EXT;
+                    pixelFormat    = GL_COMPRESSED_SIGNED_RED_RGTC1_EXT;
+                    break;
+
+                case OSG_DXGI_FORMAT_BC5_UNORM:
+                    internalFormat = GL_COMPRESSED_RED_GREEN_RGTC2_EXT;
+                    pixelFormat    = GL_COMPRESSED_RED_GREEN_RGTC2_EXT;
+                    break;
+
+                case OSG_DXGI_FORMAT_BC5_SNORM:
+                    internalFormat = GL_COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT;
+                    pixelFormat    = GL_COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT;
                     break;
 
                 default:


### PR DESCRIPTION
Think I got the formats right. Upstream is still dead atm.