### PR TITLE
Do not rely on std::endl function address and fix warnings

### DIFF
--- a/examples/osgframerenderer/CaptureSettings.cpp
+++ b/examples/osgframerenderer/CaptureSettings.cpp
@@ -104,12 +104,12 @@ static bool writeEventHandlers( osgDB::OutputStream& os, const gsc::CaptureSetti
 {
     const gsc::CaptureSettings::EventHandlers& pl = cs.getEventHandlers();
     unsigned int size = pl.size();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << pl[i].get();
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -135,12 +135,12 @@ static bool writeProperties( osgDB::OutputStream& os, const gsc::CaptureSettings
 {
     const gsc::CaptureSettings::Properties& pl = cs.getProperties();
     unsigned int size = pl.size();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << pl[i].get();
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/include/osg/Plane
+++ b/include/osg/Plane
@@ -241,7 +241,6 @@ class OSG_EXPORT Plane
 
             int noAbove = 0;
             int noBelow = 0;
-            int noOn = 0;
             for(std::vector<Vec3f>::const_iterator itr=vertices.begin();
                 itr != vertices.end();
                 ++itr)
@@ -249,7 +248,6 @@ class OSG_EXPORT Plane
                 float d = distance(*itr);
                 if (d>0.0f) ++noAbove;
                 else if (d<0.0f) ++noBelow;
-                else ++noOn;
             }
 
             if (noAbove>0)
@@ -270,7 +268,6 @@ class OSG_EXPORT Plane
 
             int noAbove = 0;
             int noBelow = 0;
-            int noOn = 0;
             for(std::vector<Vec3d>::const_iterator itr=vertices.begin();
                 itr != vertices.end();
                 ++itr)
@@ -278,7 +275,6 @@ class OSG_EXPORT Plane
                 double d = distance(*itr);
                 if (d>0.0) ++noAbove;
                 else if (d<0.0) ++noBelow;
-                else ++noOn;
             }
 
             if (noAbove>0)

--- a/include/osgDB/OutputStream
+++ b/include/osgDB/OutputStream
@@ -76,6 +76,8 @@ public:
         WRITE_EXTERNAL_FILE        /*!< Write Image::data() to disk and use it as external file */
     };
 
+    struct Endl {};
+
     OutputStream( const osgDB::Options* options );
     virtual ~OutputStream();
 
@@ -108,6 +110,7 @@ public:
     OutputStream& operator<<( const char* s ) { _out->writeString(s); return *this; }
     OutputStream& operator<<( std::ostream& (*fn)(std::ostream&) ) { _out->writeStream(fn); return *this; }
     OutputStream& operator<<( std::ios_base& (*fn)(std::ios_base&) ) { _out->writeBase(fn); return *this; }
+    OutputStream& operator<<( Endl ) { _out->writeEndl(); return *this; }
 
     OutputStream& operator<<( const ObjectGLenum& value ) { _out->writeGLenum(value); return *this; }
     OutputStream& operator<<( const ObjectProperty& prop ) { _out->writeProperty(prop); return *this; }

--- a/include/osgDB/Serializer
+++ b/include/osgDB/Serializer
@@ -314,7 +314,7 @@ public:
             if ( _useHex ) { os << std::hex << std::showbase; }
             os << value;
             if ( _useHex ) os << std::dec << std::noshowbase;
-            os << std::endl;
+            os << OutputStream::Endl{};
         }
         return true;
     }
@@ -368,7 +368,7 @@ public:
         }
         else if ( ParentType::_defaultValue!=value )
         {
-            os << os.PROPERTY((ParentType::_name).c_str()) << value << std::endl;
+            os << os.PROPERTY((ParentType::_name).c_str()) << value << OutputStream::Endl{};
         }
         return true;
     }
@@ -419,7 +419,7 @@ public:
         }
         else if ( ParentType::_defaultValue!=value )
         {
-            os << os.PROPERTY((ParentType::_name).c_str()) << value << std::endl;
+            os << os.PROPERTY((ParentType::_name).c_str()) << value << OutputStream::Endl{};
         }
         return true;
     }
@@ -487,7 +487,7 @@ public:
         }
         else if ( ParentType::_defaultValue!=value )
         {
-            os << os.PROPERTY((ParentType::_name).c_str()) << GLENUM(value) << std::endl;
+            os << os.PROPERTY((ParentType::_name).c_str()) << GLENUM(value) << OutputStream::Endl{};
         }
         return true;
     }
@@ -540,7 +540,7 @@ public:
         {
             os << os.PROPERTY((ParentType::_name).c_str());
             os.writeWrappedString( value );
-            os << std::endl;
+            os << OutputStream::Endl{};
         }
         return true;
     }
@@ -614,11 +614,11 @@ public:
             os << os.PROPERTY(_name.c_str()) << hasObject;
             if ( hasObject )
             {
-                os << os.BEGIN_BRACKET << std::endl;
+                os << os.BEGIN_BRACKET << OutputStream::Endl{};
                 os.writeObject( value );
                 os << os.END_BRACKET;
             }
-            os << std::endl;
+            os << OutputStream::Endl{};
         }
         return true;
     }
@@ -691,11 +691,11 @@ public:
             os << os.PROPERTY((ParentType::_name).c_str()) << hasObject;
             if ( hasObject )
             {
-                os << os.BEGIN_BRACKET << std::endl;
+                os << os.BEGIN_BRACKET << OutputStream::Endl{};
                 os.writeImage( value );
                 os << os.END_BRACKET;
             }
-            os << std::endl;
+            os << OutputStream::Endl{};
         }
         return true;
     }
@@ -756,7 +756,7 @@ public:
         }
         else if ( ParentType::_defaultValue!=value )
         {
-            os << os.PROPERTY((ParentType::_name).c_str()) << getString(value) << std::endl;
+            os << os.PROPERTY((ParentType::_name).c_str()) << getString(value) << OutputStream::Endl{};
         }
         return true;
     }
@@ -836,14 +836,14 @@ public:
         }
         else if ( size>0 )
         {
-            os << os.PROPERTY((_name).c_str()) << size << os.BEGIN_BRACKET << std::endl;
+            os << os.PROPERTY((_name).c_str()) << size << os.BEGIN_BRACKET << OutputStream::Endl{};
             for ( ConstIterator itr=list.begin();
                   itr!=list.end(); ++itr )
             {
                 os << (*itr);
             }
-            os << std::endl;
-            os << os.END_BRACKET << std::endl;
+            os << OutputStream::Endl{};
+            os << os.END_BRACKET << OutputStream::Endl{};
         }
         return true;
     }
@@ -1011,7 +1011,7 @@ public:
         }
         else if ( size>0 )
         {
-            os << os.PROPERTY((_name).c_str()) << size << os.BEGIN_BRACKET << std::endl;
+            os << os.PROPERTY((_name).c_str()) << size << os.BEGIN_BRACKET << OutputStream::Endl{};
             if (_numElementsOnRow==0)
             {
                 for ( ConstIterator itr=list.begin(); itr!=list.end(); ++itr )
@@ -1023,7 +1023,7 @@ public:
             {
                 for ( ConstIterator itr=list.begin(); itr!=list.end(); ++itr )
                 {
-                    os << (*itr); os << std::endl;
+                    os << (*itr); os << OutputStream::Endl{};
                 }
             }
             else
@@ -1032,12 +1032,12 @@ public:
                 for (ConstIterator itr=list.begin(); itr!=list.end(); ++itr)
                 {
                     os << (*itr);
-                    if (i==0) { os << std::endl; i = _numElementsOnRow-1; }
+                    if (i==0) { os << OutputStream::Endl{}; i = _numElementsOnRow-1; }
                     else --i;
                 }
-                if (i!=_numElementsOnRow) os << std::endl;
+                if (i!=_numElementsOnRow) os << OutputStream::Endl{};
             }
-            os << os.END_BRACKET << std::endl;
+            os << os.END_BRACKET << OutputStream::Endl{};
         }
         return true;
     }
@@ -1165,7 +1165,7 @@ public:
         }
         else if ( size>0 )
         {
-            os << os.PROPERTY((_name).c_str()) << size << os.BEGIN_BRACKET << std::endl;
+            os << os.PROPERTY((_name).c_str()) << size << os.BEGIN_BRACKET << OutputStream::Endl{};
             if (_numElementsOnRow==0)
             {
                 for ( ConstIterator itr=list.begin(); itr!=list.end(); ++itr )
@@ -1177,7 +1177,7 @@ public:
             {
                 for ( ConstIterator itr=list.begin(); itr!=list.end(); ++itr )
                 {
-                    os << (*itr); os << std::endl;
+                    os << (*itr); os << OutputStream::Endl{};
                 }
             }
             else
@@ -1186,12 +1186,12 @@ public:
                 for (ConstIterator itr=list.begin(); itr!=list.end(); ++itr)
                 {
                     os << (*itr);
-                    if (i==0) { os << std::endl; i = _numElementsOnRow-1; }
+                    if (i==0) { os << OutputStream::Endl{}; i = _numElementsOnRow-1; }
                     else --i;
                 }
-                if (i!=_numElementsOnRow) os << std::endl;
+                if (i!=_numElementsOnRow) os << OutputStream::Endl{};
             }
-            os << os.END_BRACKET << std::endl;
+            os << os.END_BRACKET << OutputStream::Endl{};
         }
         return true;
     }
@@ -1431,12 +1431,12 @@ public:
         }
         else if ( size>0 )
         {
-            os << os.PROPERTY((_name).c_str()) << size << os.BEGIN_BRACKET << std::endl;
+            os << os.PROPERTY((_name).c_str()) << size << os.BEGIN_BRACKET << OutputStream::Endl{};
             for ( ConstIterator itr=map.begin(); itr!=map.end(); ++itr )
             {
-                os << itr->first << itr->second; os << std::endl;
+                os << itr->first << itr->second; os << OutputStream::Endl{};
             }
-            os << os.END_BRACKET << std::endl;
+            os << os.END_BRACKET << OutputStream::Endl{};
         }
         return true;
     }
@@ -1531,7 +1531,7 @@ public:
             if ( !maskString.size() )
                 maskString = std::string("NONE|");
             maskString.erase(maskString.size()-1,1);
-            os << maskString << std::endl; //remove last "|"
+            os << maskString << OutputStream::Endl{}; //remove last "|"
         }
         return true;
     }

--- a/include/osgDB/StreamOperator
+++ b/include/osgDB/StreamOperator
@@ -49,6 +49,7 @@ public:
     virtual void writeString( const std::string& s ) = 0;
     virtual void writeStream( std::ostream& (*fn)(std::ostream&) ) = 0;
     virtual void writeBase( std::ios_base& (*fn)(std::ios_base&) ) = 0;
+    virtual void writeEndl() = 0;
 
     virtual void writeGLenum( const ObjectGLenum& value ) = 0;
     virtual void writeProperty( const ObjectProperty& prop ) = 0;
@@ -59,21 +60,6 @@ public:
     virtual void flush() { _out->flush(); }
 
 protected:
-    // Return true if the manipulator is std::endl
-    bool isEndl( std::ostream& (*fn)(std::ostream&) )
-    {
-#if defined (__sun) || (defined _WIN32 && !defined OSG_LIBRARY_STATIC)
-        // What a mess, but solaris does not like taking the address below
-        // windows std::endl is a template with different adresses in different dll's
-        std::stringstream ss;
-        ss << fn;
-        std::string s = ss.str();
-        return !s.empty() && s[0] == '\n';
-#else
-        return fn==static_cast<std::ostream& (*)(std::ostream&)>(std::endl);
-#endif
-    }
-
     std::ostream* _out;
     osgDB::OutputStream* _outputStream;
     bool _supportBinaryBrackets;

--- a/src/osg/dxtctool.cpp
+++ b/src/osg/dxtctool.cpp
@@ -1,6 +1,6 @@
 // dxtctool.cpp: implementation of DXTC Tools functions.
 //
-// Copyright (C) 2002 Tanguy Fautré.
+// Copyright (C) 2002 Tanguy FautrÃ©.
 // For conditions of distribution and use,
 // see copyright notice in dxtctool.h
 //

--- a/src/osg/dxtctool.h
+++ b/src/osg/dxtctool.h
@@ -2,7 +2,7 @@
 //
 //////////////////////////////////////////////////////////////////////
 //
-//  Copyright (C) 2002 Tanguy Fautr.
+//  Copyright (C) 2002 Tanguy Fautré.
 //
 //  This software is provided 'as-is', without any express or implied
 //  warranty.  In no event will the authors be held liable for any damages

--- a/src/osgDB/ClassInterface.cpp
+++ b/src/osgDB/ClassInterface.cpp
@@ -63,6 +63,7 @@ public:
     virtual void writeString( const std::string& s ) { _str.insert(_str.end(), s.begin(), s.end()); }
     virtual void writeStream( std::ostream& (*)(std::ostream&) ) {}
     virtual void writeBase( std::ios_base& (*)(std::ios_base&) ) {}
+    virtual void writeEndl() {}
     virtual void writeGLenum( const osgDB::ObjectGLenum& value ) { writeInt(value.get()); }
     virtual void writeProperty( const osgDB::ObjectProperty& prop ) { _propertyName = prop._name; }
     virtual void writeMark( const osgDB::ObjectMark& mark ) { _markName = mark._name; }

--- a/src/osgDB/OutputStream.cpp
+++ b/src/osgDB/OutputStream.cpp
@@ -193,49 +193,49 @@ OutputStream& OutputStream::operator<<( const osg::BoundingSphered& bs)
 #if 0
 OutputStream& OutputStream::operator<<( const osg::Matrixf& mat )
 {
-    *this << PROPERTY("Matrixf")<<BEGIN_BRACKET << std::endl;
+    *this << PROPERTY("Matrixf")<<BEGIN_BRACKET << Endl{};
     for ( int r=0; r<4; ++r )
     {
         *this << mat(r, 0) << mat(r, 1)
-              << mat(r, 2) << mat(r, 3) << std::endl;
+              << mat(r, 2) << mat(r, 3) << Endl{};
     }
-    *this << END_BRACKET << std::endl;
+    *this << END_BRACKET << Endl{};
     return *this;
 }
 
 OutputStream& OutputStream::operator<<( const osg::Matrixd& mat )
 {
-    *this << PROPERTY("Matrixd")<<BEGIN_BRACKET << std::endl;
+    *this << PROPERTY("Matrixd")<<BEGIN_BRACKET << Endl{};
     for ( int r=0; r<4; ++r )
     {
         *this << mat(r, 0) << mat(r, 1)
-              << mat(r, 2) << mat(r, 3) << std::endl;
+              << mat(r, 2) << mat(r, 3) << Endl{};
     }
-    *this << END_BRACKET << std::endl;
+    *this << END_BRACKET << Endl{};
     return *this;
 }
 #else
 OutputStream& OutputStream::operator<<( const osg::Matrixf& mat )
 {
-    *this << BEGIN_BRACKET << std::endl;
+    *this << BEGIN_BRACKET << Endl{};
     for ( int r=0; r<4; ++r )
     {
         *this << (double)mat(r, 0) << (double)mat(r, 1)
-              << (double)mat(r, 2) << (double)mat(r, 3) << std::endl;
+              << (double)mat(r, 2) << (double)mat(r, 3) << Endl{};
     }
-    *this << END_BRACKET << std::endl;
+    *this << END_BRACKET << Endl{};
     return *this;
 }
 
 OutputStream& OutputStream::operator<<( const osg::Matrixd& mat )
 {
-    *this << BEGIN_BRACKET << std::endl;
+    *this << BEGIN_BRACKET << Endl{};
     for ( int r=0; r<4; ++r )
     {
         *this << mat(r, 0) << mat(r, 1)
-              << mat(r, 2) << mat(r, 3) << std::endl;
+              << mat(r, 2) << mat(r, 3) << Endl{};
     }
-    *this << END_BRACKET << std::endl;
+    *this << END_BRACKET << Endl{};
     return *this;
 }
 #endif
@@ -249,7 +249,7 @@ void OutputStream::writeArray( const osg::Array* a )
     *this << PROPERTY("ArrayID") << id;
     if ( !newID )  // Shared array
     {
-        *this << std::endl;
+        *this << Endl{};
         return;
     }
 
@@ -408,7 +408,7 @@ void OutputStream::writePrimitiveSet( const osg::PrimitiveSet* p )
             const osg::DrawArrays* da = static_cast<const osg::DrawArrays*>(p);
             *this << MAPPEE(PrimitiveType, da->getMode());
             if (_targetFileVersion > 96) *this << da->getNumInstances();
-            *this << da->getFirst() << da->getCount() << std::endl;
+            *this << da->getFirst() << da->getCount() << Endl{};
         }
         break;
     case osg::PrimitiveSet::DrawArrayLengthsPrimitiveType:
@@ -463,9 +463,9 @@ void OutputStream::writeImage( const osg::Image* img )
     bool newID = false;
     unsigned int id = findOrCreateObjectID( img, newID );
 
-    if (_targetFileVersion > 94) *this << PROPERTY("ClassName") << name << std::endl;   // Write object name
+    if (_targetFileVersion > 94) *this << PROPERTY("ClassName") << name << Endl{};   // Write object name
 
-    *this << PROPERTY("UniqueID") << id << std::endl;      // Write image ID
+    *this << PROPERTY("UniqueID") << id << Endl{};      // Write image ID
     if ( getException() ) return;
 
     if (newID)
@@ -509,11 +509,11 @@ void OutputStream::writeImage( const osg::Image* img )
             }
         }
 
-        *this << PROPERTY("FileName"); writeWrappedString(imageFileName); *this << std::endl;
+        *this << PROPERTY("FileName"); writeWrappedString(imageFileName); *this << Endl{};
         *this << PROPERTY("WriteHint") << (int)img->getWriteHint();
         if ( getException() ) return;
 
-        *this << decision << std::endl;
+        *this << decision << Endl{};
 
         switch ( decision )
         {
@@ -558,17 +558,17 @@ void OutputStream::writeImage( const osg::Image* img )
                     if (r<1) r=1;
                 }
             } else { // ASCII
-                *this << PROPERTY("Origin") << img->getOrigin() << std::endl;  // _origin
-                *this << PROPERTY("Size") << img->s() << img->t() << img->r() << std::endl; // _s & _t & _r
-                *this << PROPERTY("InternalTextureFormat") << img->getInternalTextureFormat() << std::endl;  // _internalTextureFormat
-                *this << PROPERTY("PixelFormat") << img->getPixelFormat() << std::endl;  // _pixelFormat
-                *this << PROPERTY("DataType") << img->getDataType() << std::endl;  // _dataType
-                *this << PROPERTY("Packing") << img->getPacking() << std::endl;  // _packing
-                *this << PROPERTY("AllocationMode") << img->getAllocationMode() << std::endl;  // _allocationMode
+                *this << PROPERTY("Origin") << img->getOrigin() << Endl{};  // _origin
+                *this << PROPERTY("Size") << img->s() << img->t() << img->r() << Endl{}; // _s & _t & _r
+                *this << PROPERTY("InternalTextureFormat") << img->getInternalTextureFormat() << Endl{};  // _internalTextureFormat
+                *this << PROPERTY("PixelFormat") << img->getPixelFormat() << Endl{};  // _pixelFormat
+                *this << PROPERTY("DataType") << img->getDataType() << Endl{};  // _dataType
+                *this << PROPERTY("Packing") << img->getPacking() << Endl{};  // _packing
+                *this << PROPERTY("AllocationMode") << img->getAllocationMode() << Endl{};  // _allocationMode
 
                 // _data
                 *this << PROPERTY("Data") << img->getNumMipmapLevels();
-                *this << BEGIN_BRACKET << std::endl;
+                *this << BEGIN_BRACKET << Endl{};
 
                 Base64encoder e;
                 for(osg::Image::DataIterator img_itr(img); img_itr.valid(); ++img_itr)
@@ -581,7 +581,7 @@ void OutputStream::writeImage( const osg::Image* img )
                     writeWrappedString(encodedData);
                 }
 
-                *this << END_BRACKET << std::endl;
+                *this << END_BRACKET << Endl{};
             }
             break;
         case IMAGE_INLINE_FILE:
@@ -654,14 +654,14 @@ void OutputStream::writeImage( const osg::Image* img )
         writeObjectFields( img, "osg::Object" );
     }
 
-    // *this << END_BRACKET << std::endl;
+    // *this << END_BRACKET << Endl{};
 }
 
 void OutputStream::writeObject( const osg::Object* obj )
 {
     if ( !obj )
     {
-        *this << std::string("NULL") << std::endl;  // Write NULL token.
+        *this << std::string("NULL") << Endl{};  // Write NULL token.
         return;
     }
 
@@ -671,8 +671,8 @@ void OutputStream::writeObject( const osg::Object* obj )
     bool newID = false;
     unsigned int id = findOrCreateObjectID( obj, newID );
 
-    *this << name << BEGIN_BRACKET << std::endl;       // Write object name
-    *this << PROPERTY("UniqueID") << id << std::endl;  // Write object ID
+    *this << name << BEGIN_BRACKET << Endl{};       // Write object name
+    *this << PROPERTY("UniqueID") << id << Endl{};  // Write object ID
     if ( getException() ) return;
 
     if (newID)
@@ -680,7 +680,7 @@ void OutputStream::writeObject( const osg::Object* obj )
         writeObjectFields(obj);
     }
 
-    *this << END_BRACKET << std::endl;
+    *this << END_BRACKET << Endl{};
 }
 
 void OutputStream::writeObjectFields( const osg::Object* obj )
@@ -836,19 +836,19 @@ void OutputStream::start( OutputIterator* outIterator, OutputStream::WriteType t
         default: break;
         }
 
-        *this << typeString << std::endl;
-        *this << PROPERTY("#Version") << (unsigned int)OPENSCENEGRAPH_SOVERSION << std::endl;
+        *this << typeString << Endl{};
+        *this << PROPERTY("#Version") << (unsigned int)OPENSCENEGRAPH_SOVERSION << Endl{};
         *this << PROPERTY("#Generator") << std::string("OpenSceneGraph")
-              << std::string(osgGetVersion()) << std::endl;
+              << std::string(osgGetVersion()) << Endl{};
         if ( _domainVersionMap.size()>0 )
         {
             for ( VersionMap::iterator itr=_domainVersionMap.begin();
                   itr!=_domainVersionMap.end(); ++itr )
             {
-                *this << PROPERTY("#CustomDomain") << itr->first << itr->second << std::endl;
+                *this << PROPERTY("#CustomDomain") << itr->first << itr->second << Endl{};
             }
         }
-        *this << std::endl;
+        *this << Endl{};
     }
     _fields.pop_back();
 }
@@ -943,21 +943,21 @@ void OutputStream::writeArrayImplementation( const T* a, int write_size, unsigne
             {
                 if ( !(i%numInRow) )
                 {
-                    *this << std::endl << (*a)[i];
+                    *this << Endl{} << (*a)[i];
                 }
                 else
                     *this << (*a)[i];
             }
-            *this << std::endl;
+            *this << Endl{};
         }
         else
         {
-            *this << std::endl;
+            *this << Endl{};
             for ( int i=0; i<write_size; ++i )
-                *this << (*a)[i] << std::endl;
+                *this << (*a)[i] << Endl{};
         }
     }
-    *this << END_BRACKET << std::endl;
+    *this << END_BRACKET << Endl{};
 }
 
 unsigned int OutputStream::findOrCreateArrayID( const osg::Array* array, bool& newID )

--- a/src/osgPlugins/osg/AsciiStreamOperator.h
+++ b/src/osgPlugins/osg/AsciiStreamOperator.h
@@ -67,15 +67,18 @@ public:
     virtual void writeStream( std::ostream& (*fn)(std::ostream&) )
     {
         indentIfRequired(); *_out << fn;
-        if ( isEndl( fn ) )
-        {
-            _readyForIndent = true;
-        }
     }
 
     virtual void writeBase( std::ios_base& (*fn)(std::ios_base&) )
     {
         indentIfRequired(); *_out << fn;
+    }
+
+    virtual void writeEndl()
+    {
+        indentIfRequired();
+        *_out << std::endl;
+        _readyForIndent = true;
     }
 
     virtual void writeGLenum( const osgDB::ObjectGLenum& value )

--- a/src/osgPlugins/osg/BinaryStreamOperator.h
+++ b/src/osgPlugins/osg/BinaryStreamOperator.h
@@ -78,6 +78,8 @@ public:
 
     virtual void writeBase( std::ios_base& (* /*fn*/)(std::ios_base&) ) {}
 
+    virtual void writeEndl() {}
+
     virtual void writeGLenum( const osgDB::ObjectGLenum& value )
     { GLenum e = value.get(); _out->write((char*)&e, osgDB::GLENUM_SIZE); }
 

--- a/src/osgPlugins/osg/XmlStreamOperator.h
+++ b/src/osgPlugins/osg/XmlStreamOperator.h
@@ -82,35 +82,35 @@ public:
 
     virtual void writeStream( std::ostream& (*fn)(std::ostream&) )
     {
-        if ( isEndl( fn ) )
-        {
-            if ( _readLineType==PROP_LINE || _readLineType==END_BRACKET_LINE )
-            {
-                if ( _hasSubProperty )
-                {
-                    _hasSubProperty = false;
-                    popNode();  // Exit the sub-property element
-                }
-                popNode();  // Exit the property element
-            }
-            else if ( _readLineType==SUB_PROP_LINE )
-            {
-                _hasSubProperty = false;
-                popNode();  // Exit the sub-property element
-                popNode();  // Exit the property element
-            }
-            else if ( _readLineType==TEXT_LINE )
-                addToCurrentNode( fn );
-
-            setLineType( NEW_LINE );
-        }
-        else
-            addToCurrentNode( fn );
+        addToCurrentNode( fn );
     }
 
     virtual void writeBase( std::ios_base& (*fn)(std::ios_base&) )
     {
         _sstream << fn;
+    }
+
+    virtual void writeEndl()
+    {
+        if ( _readLineType==PROP_LINE || _readLineType==END_BRACKET_LINE )
+        {
+            if ( _hasSubProperty )
+            {
+                _hasSubProperty = false;
+                popNode();  // Exit the sub-property element
+            }
+            popNode();  // Exit the property element
+        }
+        else if ( _readLineType==SUB_PROP_LINE )
+        {
+            _hasSubProperty = false;
+            popNode();  // Exit the sub-property element
+            popNode();  // Exit the property element
+        }
+        else if ( _readLineType==TEXT_LINE )
+            addToCurrentNode( std::endl );
+
+        setLineType( NEW_LINE );
     }
 
     virtual void writeGLenum( const osgDB::ObjectGLenum& value )

--- a/src/osgWrappers/serializers/osg/AnimationPath.cpp
+++ b/src/osgWrappers/serializers/osg/AnimationPath.cpp
@@ -40,20 +40,20 @@ static bool writeTimeControlPointMap( osgDB::OutputStream& os, const osg::Animat
     os.writeSize(map.size());
     if ( map.size()>0 )
     {
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( osg::AnimationPath::TimeControlPointMap::const_iterator itr=map.begin();
               itr!=map.end(); ++itr )
         {
             const osg::AnimationPath::ControlPoint& pt = itr->second;
-            os << os.PROPERTY("Time") << itr->first << os.BEGIN_BRACKET << std::endl;
-            os << os.PROPERTY("Position") << pt.getPosition() << std::endl;
-            os << os.PROPERTY("Rotation") << pt.getRotation() << std::endl;
-            os << os.PROPERTY("Scale") << pt.getScale() << std::endl;
-            os << os.END_BRACKET << std::endl;
+            os << os.PROPERTY("Time") << itr->first << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+            os << os.PROPERTY("Position") << pt.getPosition() << osgDB::OutputStream::Endl{};
+            os << os.PROPERTY("Rotation") << pt.getRotation() << osgDB::OutputStream::Endl{};
+            os << os.PROPERTY("Scale") << pt.getScale() << osgDB::OutputStream::Endl{};
+            os << os.END_BRACKET << osgDB::OutputStream::Endl{};
         }
         os << os.END_BRACKET;
     }
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Billboard.cpp
+++ b/src/osgWrappers/serializers/osg/Billboard.cpp
@@ -25,13 +25,13 @@ static bool writePositionList( osgDB::OutputStream& os, const osg::Billboard& no
 {
     const osg::Billboard::PositionList& posList = node.getPositionList();
     os.writeSize(posList.size());
-    os<< os.BEGIN_BRACKET << std::endl;
+    os<< os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::Billboard::PositionList::const_iterator itr=posList.begin();
           itr!=posList.end(); ++itr )
     {
-        os << osg::Vec3d(*itr) << std::endl;
+        os << osg::Vec3d(*itr) << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/BufferIndexBinding.cpp
+++ b/src/osgWrappers/serializers/osg/BufferIndexBinding.cpp
@@ -17,7 +17,7 @@ static bool read##XXX( osgDB::InputStream& is, TYPE& node )\
 }\
 static bool write##XXX( osgDB::OutputStream& os, const TYPE& node )\
 {\
-    unsigned int size = node.get##XXX();    os << size << std::endl;    return true;\
+    unsigned int size = node.get##XXX();    os << size << osgDB::OutputStream::Endl{};    return true;\
 }
 
 GLsizei_ptrSERIALIZER(osg::BufferIndexBinding,Size)

--- a/src/osgWrappers/serializers/osg/Camera.cpp
+++ b/src/osgWrappers/serializers/osg/Camera.cpp
@@ -77,31 +77,31 @@ static void writeBufferAttachment( osgDB::OutputStream& os, const osg::Camera::A
     os << os.PROPERTY("Type");
     if ( attachment._internalFormat!=GL_NONE )
     {
-        os << (char)0 << std::endl;
-        os << os.PROPERTY("InternalFormat") << GLENUM(attachment._internalFormat) << std::endl;
+        os << (char)0 << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("InternalFormat") << GLENUM(attachment._internalFormat) << osgDB::OutputStream::Endl{};
         return;
     }
     else if ( attachment._image.valid() )
     {
-        os << (char)1 << std::endl;
+        os << (char)1 << osgDB::OutputStream::Endl{};
         os << os.PROPERTY("Image") << attachment._image.get();
     }
     else if ( attachment._texture.valid() )
     {
-        os << (char)2 << std::endl;
+        os << (char)2 << osgDB::OutputStream::Endl{};
         os << os.PROPERTY("Texture") << attachment._texture.get();
-        os << os.PROPERTY("Level") << attachment._level << std::endl;
-        os << os.PROPERTY("Face") << attachment._face << std::endl;
-        os << os.PROPERTY("MipMapGeneration") << attachment._mipMapGeneration << std::endl;
+        os << os.PROPERTY("Level") << attachment._level << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Face") << attachment._face << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("MipMapGeneration") << attachment._mipMapGeneration << osgDB::OutputStream::Endl{};
     }
     else
     {
-        os << (char)-1 << std::endl;
+        os << (char)-1 << osgDB::OutputStream::Endl{};
         return;
     }
 
-    os << os.PROPERTY("MultisampleSamples") << attachment._multisampleSamples << std::endl;
-    os << os.PROPERTY("MultisampleColorSamples") << attachment._multisampleColorSamples << std::endl;
+    os << os.PROPERTY("MultisampleSamples") << attachment._multisampleSamples << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("MultisampleColorSamples") << attachment._multisampleColorSamples <<osgDB::OutputStream::Endl{};
 }
 
 // _renderOrder & _renderOrderNum
@@ -121,7 +121,7 @@ static bool readRenderOrder( osgDB::InputStream& is, osg::Camera& node )
 static bool writeRenderOrder( osgDB::OutputStream& os, const osg::Camera& node )
 {
     writeOrderValue( os, (int)node.getRenderOrder() );
-    os << node.getRenderOrderNum() << std::endl;
+    os << node.getRenderOrderNum() << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -166,16 +166,16 @@ static bool readBufferAttachmentMap( osgDB::InputStream& is, osg::Camera& node )
 static bool writeBufferAttachmentMap( osgDB::OutputStream& os, const osg::Camera& node )
 {
     const osg::Camera::BufferAttachmentMap& map = node.getBufferAttachmentMap();
-    os.writeSize(map.size()); os<< os.BEGIN_BRACKET << std::endl;
+    os.writeSize(map.size()); os<< os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::Camera::BufferAttachmentMap::const_iterator itr=map.begin();
           itr!=map.end(); ++itr )
     {
         os << os.PROPERTY("Attachment"); writeBufferComponent( os, itr->first );
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         writeBufferAttachment( os, itr->second );
-        os << os.END_BRACKET << std::endl;
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/CompositeShape.cpp
+++ b/src/osgWrappers/serializers/osg/CompositeShape.cpp
@@ -23,12 +23,12 @@ static bool readChildren( osgDB::InputStream& is, osg::CompositeShape& shape )
 static bool writeChildren( osgDB::OutputStream& os, const osg::CompositeShape& shape )
 {
     unsigned int size = shape.getNumChildren();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << shape.getChild(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/ConvexPlanarOccluder.cpp
+++ b/src/osgWrappers/serializers/osg/ConvexPlanarOccluder.cpp
@@ -17,13 +17,13 @@ static void readConvexPlanarPolygon( osgDB::InputStream& is, osg::ConvexPlanarPo
 static void writeConvexPlanarPolygon( osgDB::OutputStream& os, const osg::ConvexPlanarPolygon& polygon )
 {
     const osg::ConvexPlanarPolygon::VertexList& vertices = polygon.getVertexList();
-    os.writeSize(vertices.size()); os<< os.BEGIN_BRACKET << std::endl;
+    os.writeSize(vertices.size()); os<< os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::ConvexPlanarPolygon::VertexList::const_iterator itr=vertices.begin();
           itr!=vertices.end(); ++itr )
     {
-        os << osg::Vec3d(*itr) << std::endl;
+        os << osg::Vec3d(*itr) << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
 }
 
 // _occluder
@@ -69,14 +69,14 @@ static bool readHoles( osgDB::InputStream& is, osg::ConvexPlanarOccluder& obj )
 static bool writeHoles( osgDB::OutputStream& os, const osg::ConvexPlanarOccluder& obj )
 {
     const osg::ConvexPlanarOccluder::HoleList& holes = obj.getHoleList();
-    os.writeSize(holes.size()); os<< os.BEGIN_BRACKET << std::endl;
+    os.writeSize(holes.size()); os<< os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::ConvexPlanarOccluder::HoleList::const_iterator itr=holes.begin();
           itr!=holes.end(); ++itr )
     {
         os << os.PROPERTY("Polygon");
         writeConvexPlanarPolygon( os, *itr );
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/DispatchCompute.cpp
+++ b/src/osgWrappers/serializers/osg/DispatchCompute.cpp
@@ -23,7 +23,7 @@ static bool writeComputeGroups( osgDB::OutputStream& os, const osg::DispatchComp
 {
     GLint numX = 0, numY = 0, numZ = 0;
     attr.getComputeGroups( numX, numY, numZ );
-    os << numX << numY << numZ << std::endl;
+    os << numX << numY << numZ << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/DrawPixels.cpp
+++ b/src/osgWrappers/serializers/osg/DrawPixels.cpp
@@ -20,7 +20,7 @@ static bool writeArea( osgDB::OutputStream& os, const osg::DrawPixels& drawable 
 {
     unsigned int x, y, w, h;
     drawable.getSubImageDimensions( x, y, w, h );
-    os << x << y << w << h << std::endl;
+    os << x << y << w << h << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Drawable.cpp
+++ b/src/osgWrappers/serializers/osg/Drawable.cpp
@@ -22,11 +22,11 @@ static bool readInitialBound( osgDB::InputStream& is, osg::Drawable& drawable )
 static bool writeInitialBound( osgDB::OutputStream& os, const osg::Drawable& drawable )
 {
     const osg::BoundingBox& bb = drawable.getInitialBound();
-    os << os.BEGIN_BRACKET << std::endl;
-    os << os.PROPERTY("Minimum") << osg::Vec3d(bb._min) << std::endl;
-    os << os.PROPERTY("Maximum") << osg::Vec3d(bb._max) << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Minimum") << osg::Vec3d(bb._min) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Maximum") << osg::Vec3d(bb._max) << osgDB::OutputStream::Endl{};
     os << os.END_BRACKET;
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/FragmentProgram.cpp
+++ b/src/osgWrappers/serializers/osg/FragmentProgram.cpp
@@ -25,13 +25,13 @@ static bool readLocalParameters( osgDB::InputStream& is, osg::FragmentProgram& f
 static bool writeLocalParameters( osgDB::OutputStream& os, const osg::FragmentProgram& fp )
 {
     const osg::FragmentProgram::LocalParamList& params = fp.getLocalParameters();
-    os.writeSize(params.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(params.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::FragmentProgram::LocalParamList::const_iterator itr=params.begin();
           itr!=params.end(); ++itr )
     {
-        os << itr->first << osg::Vec4d(itr->second) << std::endl;
+        os << itr->first << osg::Vec4d(itr->second) << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -57,13 +57,13 @@ static bool readMatrices( osgDB::InputStream& is, osg::FragmentProgram& fp )
 static bool writeMatrices( osgDB::OutputStream& os, const osg::FragmentProgram& fp )
 {
     const osg::FragmentProgram::MatrixList& matrices = fp.getMatrices();
-    os.writeSize(matrices.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(matrices.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::FragmentProgram::MatrixList::const_iterator itr=matrices.begin();
           itr!=matrices.end(); ++itr )
     {
-        os << (unsigned int)itr->first << osg::Matrixd(itr->second) << std::endl;
+        os << (unsigned int)itr->first << osg::Matrixd(itr->second) << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Geode.cpp
+++ b/src/osgWrappers/serializers/osg/Geode.cpp
@@ -28,12 +28,12 @@ static bool readDrawables( osgDB::InputStream& is, osg::Geode& node )
 static bool writeDrawables( osgDB::OutputStream& os, const osg::Geode& node )
 {
     unsigned int size = node.getNumDrawables();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << node.getDrawable(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Geometry.cpp
+++ b/src/osgWrappers/serializers/osg/Geometry.cpp
@@ -49,15 +49,15 @@ static void writeArray( osgDB::OutputStream& os, const osg::Array* array)
 {
     os << os.PROPERTY("Array") << (array!=0);
     if ( array!=0 ) os << array;
-    else os << std::endl;
+    else os << osgDB::OutputStream::Endl{};
 
     const osg::IndexArray* indices = (array!=0) ? dynamic_cast<const osg::IndexArray*>(array->getUserData()) : 0;
     os << os.PROPERTY("Indices") << (indices!=0);
     if ( indices!=0 ) os << indices;
-    else os << std::endl;
+    else os << osgDB::OutputStream::Endl{};
 
-    os << os.PROPERTY("Binding"); writeAttributeBinding(os, osg::getBinding(array)); os << std::endl;
-    os << os.PROPERTY("Normalize") << ((array!=0 && array->getNormalize()) ? 1:0) << std::endl;
+    os << os.PROPERTY("Binding"); writeAttributeBinding(os, osg::getBinding(array)); os << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Normalize") << ((array!=0 && array->getNormalize()) ? 1:0) << osgDB::OutputStream::Endl{};
 }
 
 #define ADD_ARRAYDATA_FUNCTIONS( ORIGINAL_PROP, PROP ) \
@@ -71,9 +71,9 @@ static void writeArray( osgDB::OutputStream& os, const osg::Array* array)
         return true; \
     } \
     static bool write##ORIGINAL_PROP( osgDB::OutputStream& os, const osg::Geometry& geom ) { \
-        os << os.BEGIN_BRACKET << std::endl; \
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; \
         writeArray(os, geom.get##PROP()); \
-        os << os.END_BRACKET << std::endl; \
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 
@@ -98,13 +98,13 @@ ADD_ARRAYDATA_FUNCTIONS( FogCoordData, FogCoordArray )
     } \
     static bool write##ORIGINAL_PROP( osgDB::OutputStream& os, const osg::Geometry& geom ) { \
         const osg::Geometry::ArrayList& LISTNAME = geom.get##LISTNAME(); \
-        os.writeSize(LISTNAME.size()); os << os.BEGIN_BRACKET << std::endl; \
+        os.writeSize(LISTNAME.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; \
         for ( osg::Geometry::ArrayList::const_iterator itr=LISTNAME.begin(); \
               itr!=LISTNAME.end(); ++itr ) { \
-            os << os.PROPERTY("Data") << os.BEGIN_BRACKET << std::endl; \
-            writeArray(os, itr->get()); os << os.END_BRACKET << std::endl; \
+            os << os.PROPERTY("Data") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; \
+            writeArray(os, itr->get()); os << os.END_BRACKET << osgDB::OutputStream::Endl{}; \
         } \
-        os << os.END_BRACKET << std::endl; \
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 

--- a/src/osgWrappers/serializers/osg/Group.cpp
+++ b/src/osgWrappers/serializers/osg/Group.cpp
@@ -25,12 +25,12 @@ static bool readChildren( osgDB::InputStream& is, osg::Group& node )
 static bool writeChildren( osgDB::OutputStream& os, const osg::Group& node )
 {
     unsigned int size = node.getNumChildren();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << node.getChild(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/HeightField.cpp
+++ b/src/osgWrappers/serializers/osg/HeightField.cpp
@@ -19,7 +19,7 @@ static bool readArea( osgDB::InputStream& is, osg::HeightField& shape )
 
 static bool writeArea( osgDB::OutputStream& os, const osg::HeightField& shape )
 {
-    os << shape.getNumColumns() << shape.getNumRows() << std::endl;
+    os << shape.getNumColumns() << shape.getNumRows() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/ImageSequence.cpp
+++ b/src/osgWrappers/serializers/osg/ImageSequence.cpp
@@ -25,15 +25,15 @@ static bool readFileNames( osgDB::InputStream& is, osg::ImageSequence& image )
 static bool writeFileNames( osgDB::OutputStream& os, const osg::ImageSequence& image )
 {
     const osg::ImageSequence::ImageDataList& imageDataList = image.getImageDataList();
-    os.writeSize(imageDataList.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(imageDataList.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::ImageSequence::ImageDataList::const_iterator itr=imageDataList.begin();
           itr!=imageDataList.end();
           ++itr )
     {
         os.writeWrappedString( itr->_filename );
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -58,14 +58,14 @@ static bool readImages( osgDB::InputStream& is, osg::ImageSequence& image )
 static bool writeImages( osgDB::OutputStream& os, const osg::ImageSequence& image)
 {
     const osg::ImageSequence::ImageDataList& imageDataList = image.getImageDataList();
-    os.writeSize(imageDataList.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(imageDataList.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::ImageSequence::ImageDataList::const_iterator itr=imageDataList.begin();
           itr!=imageDataList.end();
           ++itr )
     {
         os.writeObject( (*itr)._image.get() );
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/LOD.cpp
+++ b/src/osgWrappers/serializers/osg/LOD.cpp
@@ -19,7 +19,7 @@ static bool readUserCenter( osgDB::InputStream& is, osg::LOD& node )
 
 static bool writeUserCenter( osgDB::OutputStream& os, const osg::LOD& node )
 {
-    os << osg::Vec3d(node.getCenter()) << (double)node.getRadius() << std::endl;
+    os << osg::Vec3d(node.getCenter()) << (double)node.getRadius() << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -45,13 +45,13 @@ static bool readRangeList( osgDB::InputStream& is, osg::LOD& node )
 static bool writeRangeList( osgDB::OutputStream& os, const osg::LOD& node )
 {
     const osg::LOD::RangeList& ranges = node.getRangeList();
-    os.writeSize(ranges.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(ranges.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::LOD::RangeList::const_iterator itr=ranges.begin();
           itr!=ranges.end(); ++itr )
     {
-        os << itr->first << itr->second << std::endl;
+        os << itr->first << itr->second << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Material.cpp
+++ b/src/osgWrappers/serializers/osg/Material.cpp
@@ -21,7 +21,7 @@
     static bool write##PROP( osgDB::OutputStream& os, const osg::Material& attr ) { \
         os << attr.get##PROP##FrontAndBack(); \
         os << os.PROPERTY("Front") << TYPE(attr.get##PROP(osg::Material::FRONT)); \
-        os << os.PROPERTY("Back") << TYPE(attr.get##PROP(osg::Material::BACK)) << std::endl; \
+        os << os.PROPERTY("Back") << TYPE(attr.get##PROP(osg::Material::BACK)) << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 

--- a/src/osgWrappers/serializers/osg/Node.cpp
+++ b/src/osgWrappers/serializers/osg/Node.cpp
@@ -24,10 +24,10 @@ static bool readInitialBound( osgDB::InputStream& is, osg::Node& node )
 static bool writeInitialBound( osgDB::OutputStream& os, const osg::Node& node )
 {
     const osg::BoundingSphere& bs = node.getInitialBound();
-    os << os.BEGIN_BRACKET << std::endl;
-    os << os.PROPERTY("Center") << osg::Vec3d(bs.center()) << std::endl;
-    os << os.PROPERTY("Radius") << double(bs.radius()) << std::endl;
-    os << os.END_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Center") << osg::Vec3d(bs.center()) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Radius") << double(bs.radius()) << osgDB::OutputStream::Endl{};
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -53,14 +53,14 @@ static bool readDescriptions( osgDB::InputStream& is, osg::Node& node )
 static bool writeDescriptions( osgDB::OutputStream& os, const osg::Node& node )
 {
     const osg::Node::DescriptionList& slist = node.getDescriptions();
-    os.writeSize(slist.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(slist.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::Node::DescriptionList::const_iterator itr=slist.begin();
           itr!=slist.end(); ++itr )
     {
         os.writeWrappedString( *itr );
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Object.cpp
+++ b/src/osgWrappers/serializers/osg/Object.cpp
@@ -22,9 +22,9 @@ static bool readUserData( osgDB::InputStream& is, osg::Object& obj )
 
 static bool writeUserData( osgDB::OutputStream& os, const osg::Object& obj )
 {
-    os << os.BEGIN_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     os.writeObject(dynamic_cast<const osg::Object*>(obj.getUserData()));
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/PagedLOD.cpp
+++ b/src/osgWrappers/serializers/osg/PagedLOD.cpp
@@ -34,7 +34,7 @@ static bool writeDatabasePath( osgDB::OutputStream& os, const osg::PagedLOD& nod
     os << (!node.getDatabasePath().empty());
     if ( !node.getDatabasePath().empty() )
         os.writeWrappedString( node.getDatabasePath() );
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -70,21 +70,21 @@ static bool readRangeDataList( osgDB::InputStream& is, osg::PagedLOD& node )
 static bool writeRangeDataList( osgDB::OutputStream& os, const osg::PagedLOD& node )
 {
     unsigned int size = node.getNumFileNames();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os.writeWrappedString( node.getFileName(i) );
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
 
     size = node.getNumPriorityOffsets();
-    os << os.PROPERTY("PriorityList") << size << os.BEGIN_BRACKET << std::endl;
+    os << os.PROPERTY("PriorityList") << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
-        os << node.getPriorityOffset(i) << node.getPriorityScale(i) << std::endl;
+        os << node.getPriorityOffset(i) << node.getPriorityScale(i) << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -122,7 +122,7 @@ static bool writeChildren( osgDB::OutputStream& os, const osg::PagedLOD& node )
     unsigned int realSize = size-dynamicLoadedSize; os << realSize;
     if ( realSize>0 )
     {
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( unsigned int i=0; i<size; ++i )
         {
             if ( !node.getFileName(i).empty() ) continue;
@@ -131,7 +131,7 @@ static bool writeChildren( osgDB::OutputStream& os, const osg::PagedLOD& node )
         }
         os << os.END_BRACKET;
     }
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/PolygonMode.cpp
+++ b/src/osgWrappers/serializers/osg/PolygonMode.cpp
@@ -37,15 +37,15 @@ static bool readMode( osgDB::InputStream& is, osg::PolygonMode& attr )
 
 static bool writeMode( osgDB::OutputStream& os, const osg::PolygonMode& attr )
 {
-    os << os.PROPERTY("UseFrontAndBack") << attr.getFrontAndBack() << std::endl;
+    os << os.PROPERTY("UseFrontAndBack") << attr.getFrontAndBack() << osgDB::OutputStream::Endl{};
 
     os << os.PROPERTY("Front");
     writeModeValue( os, (int)attr.getMode(osg::PolygonMode::FRONT) );
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
 
     os << os.PROPERTY("Back");
     writeModeValue( os, (int)attr.getMode(osg::PolygonMode::BACK) );
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/PolygonStipple.cpp
+++ b/src/osgWrappers/serializers/osg/PolygonStipple.cpp
@@ -39,12 +39,12 @@ static bool writeMask( osgDB::OutputStream& os, const osg::PolygonStipple& attr 
     else
     {
         const GLubyte* mask = attr.getMask();
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( unsigned int i=0; i<128; ++i )
         {
-            os << std::hex << mask[i] << std::dec << std::endl;
+            os << std::hex << mask[i] << std::dec << osgDB::OutputStream::Endl{};
         }
-        os << os.END_BRACKET << std::endl;
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
     return true;
 }

--- a/src/osgWrappers/serializers/osg/PrimitiveRestartIndex.cpp
+++ b/src/osgWrappers/serializers/osg/PrimitiveRestartIndex.cpp
@@ -21,7 +21,7 @@ static bool readRestartIndex( osgDB::InputStream& is, osg::PrimitiveRestartIndex
 
 static bool writeRestartIndex( osgDB::OutputStream& os, const osg::PrimitiveRestartIndex& attr )
 {
-    os << attr.getRestartIndex() << std::endl;
+    os << attr.getRestartIndex() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/PrimitiveSetIndirect.cpp
+++ b/src/osgWrappers/serializers/osg/PrimitiveSetIndirect.cpp
@@ -55,7 +55,7 @@ static bool writeDACommands( osgDB::OutputStream& os, const osg::DefaultIndirect
 {
     unsigned int size = node.getNumElements();
     osg::DefaultIndirectCommandDrawArrays& nonconstnode =const_cast<osg::DefaultIndirectCommandDrawArrays&>(node);
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << nonconstnode.count(i);
@@ -63,7 +63,7 @@ static bool writeDACommands( osgDB::OutputStream& os, const osg::DefaultIndirect
         os << nonconstnode.first(i);
         os << nonconstnode.baseInstance(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -103,7 +103,7 @@ static bool writeDECommands( osgDB::OutputStream& os, const osg::DefaultIndirect
 {
     unsigned int size = node.getNumElements();
     osg::DefaultIndirectCommandDrawElements& nonconstnode =const_cast<osg::DefaultIndirectCommandDrawElements&>(node);
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << nonconstnode.count(i);
@@ -112,7 +112,7 @@ static bool writeDECommands( osgDB::OutputStream& os, const osg::DefaultIndirect
         os << nonconstnode.baseVertex(i);
         os << nonconstnode.baseInstance(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Program.cpp
+++ b/src/osgWrappers/serializers/osg/Program.cpp
@@ -18,12 +18,12 @@
     static bool write##PROP( osgDB::OutputStream& os, const osg::Program& attr ) \
     { \
         const osg::Program::TYPE& plist = attr.get##TYPE(); \
-        os.writeSize(plist.size()); os << os.BEGIN_BRACKET << std::endl; \
+        os.writeSize(plist.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; \
         for ( osg::Program::TYPE::const_iterator itr=plist.begin(); \
               itr!=plist.end(); ++itr ) { \
-            os << itr->first << itr->second << std::endl; \
+            os << itr->first << itr->second << osgDB::OutputStream::Endl{}; \
         } \
-        os << os.END_BRACKET << std::endl; \
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 
@@ -39,7 +39,7 @@ PROGRAM_LIST_FUNC( FragDataBinding, FragDataBindingList, BindFragDataLocation )
         return true; \
     } \
     static bool write##PROP(osgDB::OutputStream& os, const osg::Program& attr) { \
-        os << os.PROPERTY(#NAME) << (int)attr.getParameter(NAME) << std::endl; \
+        os << os.PROPERTY(#NAME) << (int)attr.getParameter(NAME) << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 
@@ -68,12 +68,12 @@ static bool readShaders( osgDB::InputStream& is, osg::Program& attr )
 static bool writeShaders( osgDB::OutputStream& os, const osg::Program& attr )
 {
     unsigned int size = attr.getNumShaders();
-    os.writeSize(size); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(size); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << attr.getShader(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 // feedBackVaryings
@@ -96,12 +96,12 @@ static bool readFeedBackVaryingsName( osgDB::InputStream& is, osg::Program& attr
 static bool writeFeedBackVaryingsName( osgDB::OutputStream& os, const osg::Program& attr )
 {
 	unsigned int size = attr.getNumTransformFeedBackVaryings();
-	os.writeSize(size); os << os.BEGIN_BRACKET << std::endl;
+	os.writeSize(size); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
 	for ( unsigned int i=0; i<size; ++i )
 	{
-		os << attr.getTransformFeedBackVarying(i)<< std::endl;
+		os << attr.getTransformFeedBackVarying(i)<< osgDB::OutputStream::Endl{};
 	}
-	os << os.END_BRACKET << std::endl;
+	os << os.END_BRACKET << osgDB::OutputStream::Endl{};
 	return true;
 }
 // feedBack mode
@@ -118,7 +118,7 @@ static bool readFeedBackMode( osgDB::InputStream& is, osg::Program& attr )
 }
 static bool writeFeedBackMode( osgDB::OutputStream& os, const osg::Program& attr )
 {
-	os << attr.getTransformFeedBackMode()<< std::endl;
+	os << attr.getTransformFeedBackMode()<< osgDB::OutputStream::Endl{};
 	return true;
 }
 // _numGroupsX/Y/Z
@@ -137,7 +137,7 @@ static bool readComputeGroups( osgDB::InputStream& is, osg::Program& attr )
 static bool writeComputeGroups( osgDB::OutputStream& os, const osg::Program& attr )
 {
     GLint numX = 0, numY = 0, numZ = 0;
-    os << numX << numY << numZ << std::endl;
+    os << numX << numY << numZ << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -163,14 +163,14 @@ static bool readBindUniformBlock( osgDB::InputStream& is, osg::Program& p )
 static bool writeBindUniformBlock( osgDB::OutputStream& os, const osg::Program& p )
 {
     unsigned int size = p.getUniformBlockBindingList().size();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for(osg::Program::UniformBlockBindingList::const_iterator bbit = p.getUniformBlockBindingList().begin();
         bbit != p.getUniformBlockBindingList().end(); ++bbit)
     {
         os << bbit->first;
         os << bbit->second;
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/ProxyNode.cpp
+++ b/src/osgWrappers/serializers/osg/ProxyNode.cpp
@@ -26,13 +26,13 @@ static bool readFileNames( osgDB::InputStream& is, osg::ProxyNode& node )
 
 static bool writeFileNames( osgDB::OutputStream& os, const osg::ProxyNode& node )
 {
-    os << node.getNumFileNames() << os.BEGIN_BRACKET << std::endl;
+    os << node.getNumFileNames() << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<node.getNumFileNames(); ++i )
     {
         os.writeWrappedString( node.getFileName(i) );
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -70,7 +70,7 @@ static bool writeChildren( osgDB::OutputStream& os, const osg::ProxyNode& node )
     unsigned int realSize = size-dynamicLoadedSize; os << realSize;
     if ( realSize>0 )
     {
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( unsigned int i=0; i<size; ++i )
         {
             if ( !node.getFileName(i).empty() ) continue;
@@ -79,7 +79,7 @@ static bool writeChildren( osgDB::OutputStream& os, const osg::ProxyNode& node )
         }
         os << os.END_BRACKET;
     }
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -99,7 +99,7 @@ static bool readUserCenter( osgDB::InputStream& is, osg::ProxyNode& node )
 
 static bool writeUserCenter( osgDB::OutputStream& os, const osg::ProxyNode& node )
 {
-    os << osg::Vec3d(node.getCenter()) << (double)node.getRadius() << std::endl;
+    os << osg::Vec3d(node.getCenter()) << (double)node.getRadius() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/SampleMaski.cpp
+++ b/src/osgWrappers/serializers/osg/SampleMaski.cpp
@@ -22,7 +22,7 @@ static bool readMasks( osgDB::InputStream& is, osg::SampleMaski& attr )
 
 static bool writeMasks( osgDB::OutputStream& os, const osg::SampleMaski& attr )
 {
-    os << attr.getMask( 0u ) << attr.getMask( 1u ) << std::endl;
+    os << attr.getMask( 0u ) << attr.getMask( 1u ) << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Scissor.cpp
+++ b/src/osgWrappers/serializers/osg/Scissor.cpp
@@ -18,7 +18,7 @@ static bool readArea( osgDB::InputStream& is, osg::Scissor& attr )
 
 static bool writeArea( osgDB::OutputStream& os, const osg::Scissor& attr )
 {
-    os << attr.x() << attr.y() << attr.width() << attr.height() << std::endl;
+    os << attr.x() << attr.y() << attr.width() << attr.height() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Shader.cpp
+++ b/src/osgWrappers/serializers/osg/Shader.cpp
@@ -33,14 +33,14 @@ static bool writeShaderSource( osgDB::OutputStream& os, const osg::Shader& shade
         lines.push_back( line );
     }
 
-    os.writeSize(lines.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(lines.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( std::vector<std::string>::const_iterator itr=lines.begin();
           itr!=lines.end(); ++itr )
     {
         os.writeWrappedString( *itr );
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/ShaderBinary.cpp
+++ b/src/osgWrappers/serializers/osg/ShaderBinary.cpp
@@ -45,12 +45,12 @@ static bool writeData( osgDB::OutputStream& os, const osg::ShaderBinary& sb )
     {
         const unsigned char* data = sb.getData();
         os << (unsigned int)sb.getSize();
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( unsigned int i=0; i<sb.getSize(); ++i )
         {
-            os << std::hex << data[i] << std::dec << std::endl;
+            os << std::hex << data[i] << std::dec << osgDB::OutputStream::Endl{};
         }
-        os << os.END_BRACKET << std::endl;
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
     return true;
 }

--- a/src/osgWrappers/serializers/osg/StateSet.cpp
+++ b/src/osgWrappers/serializers/osg/StateSet.cpp
@@ -77,17 +77,17 @@ static void writeModes( osgDB::OutputStream& os, const osg::StateSet::ModeList& 
     os.writeSize(modes.size());
     if ( modes.size()>0 )
     {
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( osg::StateSet::ModeList::const_iterator itr=modes.begin();
               itr!=modes.end(); ++itr )
         {
             os << GLENUM(itr->first);
             writeValue(os, itr->second);
-            os << std::endl;
+            os << osgDB::OutputStream::Endl{};
         }
         os << os.END_BRACKET;
     }
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
 }
 
 static void writeAttributes( osgDB::OutputStream& os, const osg::StateSet::AttributeList& attrs )
@@ -95,18 +95,18 @@ static void writeAttributes( osgDB::OutputStream& os, const osg::StateSet::Attri
     os.writeSize(attrs.size());
     if ( attrs.size()>0 )
     {
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( osg::StateSet::AttributeList::const_iterator itr=attrs.begin();
               itr!=attrs.end(); ++itr )
         {
             os << itr->second.first.get();
             os << os.PROPERTY("Value");
             writeValue(os, itr->second.second);
-            os << std::endl;
+            os << osgDB::OutputStream::Endl{};
         }
         os << os.END_BRACKET;
     }
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
 }
 
 // _modeList
@@ -183,14 +183,14 @@ static bool readTextureModeList( osgDB::InputStream& is, osg::StateSet& ss )
 static bool writeTextureModeList( osgDB::OutputStream& os, const osg::StateSet& ss )
 {
     const osg::StateSet::TextureModeList& tml = ss.getTextureModeList();
-    os.writeSize(tml.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(tml.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::StateSet::TextureModeList::const_iterator itr=tml.begin();
           itr!=tml.end(); ++itr )
     {
         os << os.PROPERTY("Data");
         writeModes( os, *itr );
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -222,14 +222,14 @@ static bool readTextureAttributeList( osgDB::InputStream& is, osg::StateSet& ss 
 static bool writeTextureAttributeList( osgDB::OutputStream& os, const osg::StateSet& ss )
 {
     const osg::StateSet::TextureAttributeList& tal = ss.getTextureAttributeList();
-    os.writeSize(tal.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(tal.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::StateSet::TextureAttributeList::const_iterator itr=tal.begin();
           itr!=tal.end(); ++itr )
     {
         os << os.PROPERTY("Data");
         writeAttributes( os, *itr );
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -257,16 +257,16 @@ static bool readUniformList( osgDB::InputStream& is, osg::StateSet& ss )
 static bool writeUniformList( osgDB::OutputStream& os, const osg::StateSet& ss )
 {
     const osg::StateSet::UniformList& ul = ss.getUniformList();
-    os.writeSize(ul.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(ul.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::StateSet::UniformList::const_iterator itr=ul.begin();
           itr!=ul.end(); ++itr )
     {
         os << itr->second.first.get();
         os << os.PROPERTY("Value");
         writeValue(os, itr->second.second);
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -300,7 +300,7 @@ static bool readDefineList( osgDB::InputStream& is, osg::StateSet& ss )
 static bool writeDefineList( osgDB::OutputStream& os, const osg::StateSet& ss )
 {
     const osg::StateSet::DefineList& df = ss.getDefineList();
-    os.writeSize(df.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(df.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::StateSet::DefineList::const_iterator itr=df.begin();
           itr!=df.end(); ++itr )
     {
@@ -308,9 +308,9 @@ static bool writeDefineList( osgDB::OutputStream& os, const osg::StateSet& ss )
         os.writeWrappedString(itr->second.first);
         os << os.PROPERTY("Value");
         writeValue(os, itr->second.second);
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/StencilTwoSided.cpp
+++ b/src/osgWrappers/serializers/osg/StencilTwoSided.cpp
@@ -41,7 +41,7 @@ USER_WRITE_FUNC( Operation, writeOperation )
     static bool write##PROP( osgDB::OutputStream& os, const osg::StencilTwoSided& attr ) { \
         os << os.PROPERTY("Front") << attr.get##PROP(osg::StencilTwoSided::FRONT); \
         os << os.PROPERTY("Back") << attr.get##PROP(osg::StencilTwoSided::BACK); \
-        os << std::endl; return true; }
+        os << osgDB::OutputStream::Endl{}; return true; }
 
 #define STENCIL_USER_VALUE_FUNC( PROP, TYPE ) \
     static bool check##PROP( const osg::StencilTwoSided& attr ) { return true; } \
@@ -54,7 +54,7 @@ USER_WRITE_FUNC( Operation, writeOperation )
     static bool write##PROP( osgDB::OutputStream& os, const osg::StencilTwoSided& attr ) { \
         os << os.PROPERTY("Front"); write##TYPE(os, (int)attr.get##PROP(osg::StencilTwoSided::FRONT)); \
         os << os.PROPERTY("Back"); write##TYPE(os, (int)attr.get##PROP(osg::StencilTwoSided::BACK)); \
-        os << std::endl; return true; }
+        os << osgDB::OutputStream::Endl{}; return true; }
 
 STENCIL_USER_VALUE_FUNC( Function, Function )
 STENCIL_INT_VALUE_FUNC( FunctionRef, int )

--- a/src/osgWrappers/serializers/osg/TexGen.cpp
+++ b/src/osgWrappers/serializers/osg/TexGen.cpp
@@ -11,7 +11,7 @@
         return true; \
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osg::TexGen& tex ) { \
-        os << tex.getPlane(COORD) << std::endl; \
+        os << tex.getPlane(COORD) << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 

--- a/src/osgWrappers/serializers/osg/Texture.cpp
+++ b/src/osgWrappers/serializers/osg/Texture.cpp
@@ -11,7 +11,7 @@
         return true; \
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osg::Texture& tex ) { \
-        os << GLENUM(tex.getWrap(VALUE)) << std::endl; \
+        os << GLENUM(tex.getWrap(VALUE)) << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 
@@ -27,7 +27,7 @@ WRAP_FUNCTIONS( WRAP_R, osg::Texture::WRAP_R )
         return true; \
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osg::Texture& tex ) { \
-        os << GLENUM(tex.getFilter(VALUE)) << std::endl; \
+        os << GLENUM(tex.getFilter(VALUE)) << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 
@@ -43,7 +43,7 @@ FILTER_FUNCTIONS( MAG_FILTER, osg::Texture::MAG_FILTER )
         return true; \
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osg::Texture& tex ) { \
-        os << GLENUM(tex.get##PROP()) << std::endl; \
+        os << GLENUM(tex.get##PROP()) << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 
@@ -64,9 +64,9 @@ static bool readInternalFormat( osgDB::InputStream& is, osg::Texture& tex )
 static bool writeInternalFormat( osgDB::OutputStream& os, const osg::Texture& tex )
 {
     if ( os.isBinary() && tex.getInternalFormatMode()!=osg::Texture::USE_USER_DEFINED_FORMAT )
-        os << GLENUM(GL_NONE) << std::endl;  // Avoid use of OpenGL extensions
+        os << GLENUM(GL_NONE) << osgDB::OutputStream::Endl{};  // Avoid use of OpenGL extensions
     else
-        os << GLENUM(tex.getInternalFormat()) << std::endl;
+        os << GLENUM(tex.getInternalFormat()) << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -99,7 +99,7 @@ static bool writeImageAttachment( osgDB::OutputStream& os, const osg::Texture& a
 {
     DummyImageAttachment attachment;
     os << attachment.unit << attachment.level << attachment.layered
-       << attachment.layer << attachment.access << attachment.format << std::endl;
+       << attachment.layer << attachment.access << attachment.format << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -190,7 +190,7 @@ static bool readSwizzle( osgDB::InputStream& is, osg::Texture& attr )
 
 static bool writeSwizzle( osgDB::OutputStream& os, const osg::Texture& attr )
 {
-    os << swizzleToString(attr.getSwizzle()) << std::endl;
+    os << swizzleToString(attr.getSwizzle()) << osgDB::OutputStream::Endl{};
 
     return true;
 }

--- a/src/osgWrappers/serializers/osg/Texture2DArray.cpp
+++ b/src/osgWrappers/serializers/osg/Texture2DArray.cpp
@@ -23,12 +23,12 @@ static bool readImages( osgDB::InputStream& is, osg::Texture2DArray& tex )
 static bool writeImages( osgDB::OutputStream& os, const osg::Texture2DArray& tex )
 {
     unsigned int size = tex.getNumImages();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << tex.getImage(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/TextureCubeMap.cpp
+++ b/src/osgWrappers/serializers/osg/TextureCubeMap.cpp
@@ -17,10 +17,10 @@
         const osg::Image* image = tex.getImage(FACE); \
         os << (image!=NULL); \
         if ( image!=NULL ) { \
-            os << os.BEGIN_BRACKET << std::endl << image; \
+            os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{} << image; \
             os << os.END_BRACKET; \
         } \
-        os << std::endl; \
+        os << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 

--- a/src/osgWrappers/serializers/osg/TransferFunction1D.cpp
+++ b/src/osgWrappers/serializers/osg/TransferFunction1D.cpp
@@ -27,13 +27,13 @@ static bool readColorMap( osgDB::InputStream& is, osg::TransferFunction1D& func 
 static bool writeColorMap( osgDB::OutputStream& os, const osg::TransferFunction1D& func )
 {
     const osg::TransferFunction1D::ColorMap& map = func.getColorMap();
-    os.writeSize(map.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(map.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::TransferFunction1D::ColorMap::const_iterator itr=map.begin();
           itr!=map.end(); ++itr )
     {
-        os << itr->first << itr->second << std::endl;
+        os << itr->first << itr->second << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 #endif

--- a/src/osgWrappers/serializers/osg/UserDataContainer.cpp
+++ b/src/osgWrappers/serializers/osg/UserDataContainer.cpp
@@ -20,9 +20,9 @@ static bool readUDC_UserData( osgDB::InputStream& is, osg::DefaultUserDataContai
 
 static bool writeUDC_UserData( osgDB::OutputStream& os, const osg::DefaultUserDataContainer& udc )
 {
-    os << os.BEGIN_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     os.writeObject(dynamic_cast<const osg::Object*>(udc.getUserData()));
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -48,14 +48,14 @@ static bool readUDC_Descriptions( osgDB::InputStream& is, osg::DefaultUserDataCo
 static bool writeUDC_Descriptions( osgDB::OutputStream& os, const osg::DefaultUserDataContainer& udc )
 {
     const osg::UserDataContainer::DescriptionList& slist = udc.getDescriptions();
-    os.writeSize(slist.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(slist.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::UserDataContainer::DescriptionList::const_iterator itr=slist.begin();
           itr!=slist.end(); ++itr )
     {
         os.writeWrappedString( *itr );
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -80,12 +80,12 @@ static bool readUDC_UserObjects( osgDB::InputStream& is, osg::DefaultUserDataCon
 static bool writeUDC_UserObjects( osgDB::OutputStream& os, const osg::DefaultUserDataContainer& udc )
 {
     unsigned int numObjects = udc.getNumUserObjects();
-    os.writeSize(numObjects); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(numObjects); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<numObjects; ++i )
     {
         os << udc.getUserObject(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/VertexProgram.cpp
+++ b/src/osgWrappers/serializers/osg/VertexProgram.cpp
@@ -25,13 +25,13 @@ static bool readLocalParameters( osgDB::InputStream& is, osg::VertexProgram& vp 
 static bool writeLocalParameters( osgDB::OutputStream& os, const osg::VertexProgram& vp )
 {
     const osg::VertexProgram::LocalParamList& params = vp.getLocalParameters();
-    os.writeSize(params.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(params.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::VertexProgram::LocalParamList::const_iterator itr=params.begin();
           itr!=params.end(); ++itr )
     {
-        os << itr->first << osg::Vec4d(itr->second) << std::endl;
+        os << itr->first << osg::Vec4d(itr->second) << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -57,13 +57,13 @@ static bool readMatrices( osgDB::InputStream& is, osg::VertexProgram& vp )
 static bool writeMatrices( osgDB::OutputStream& os, const osg::VertexProgram& vp )
 {
     const osg::VertexProgram::MatrixList& matrices = vp.getMatrices();
-    os.writeSize(matrices.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(matrices.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osg::VertexProgram::MatrixList::const_iterator itr=matrices.begin();
           itr!=matrices.end(); ++itr )
     {
-        os << (unsigned int)itr->first << osg::Matrixd(itr->second) << std::endl;
+        os << (unsigned int)itr->first << osg::Matrixd(itr->second) << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osg/Viewport.cpp
+++ b/src/osgWrappers/serializers/osg/Viewport.cpp
@@ -18,7 +18,7 @@ static bool readArea( osgDB::InputStream& is, osg::Viewport& attr )
 
 static bool writeArea( osgDB::OutputStream& os, const osg::Viewport& attr )
 {
-    os << attr.x() << attr.y() << attr.width() << attr.height() << std::endl;
+    os << attr.x() << attr.y() << attr.width() << attr.height() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgAnimation/Animation.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/Animation.cpp
@@ -80,8 +80,8 @@ static void readContainer2( osgDB::InputStream& is, ContainerType* container )
 
 static void writeChannel( osgDB::OutputStream& os, osgAnimation::Channel* ch )
 {
-    os << os.PROPERTY("Name"); os.writeWrappedString(ch->getName()); os << std::endl;
-    os << os.PROPERTY("TargetName");os.writeWrappedString(ch->getTargetName()); os << std::endl;
+    os << os.PROPERTY("Name"); os.writeWrappedString(ch->getName()); os << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("TargetName");os.writeWrappedString(ch->getTargetName()); os << osgDB::OutputStream::Endl{};
 }
 
 template <typename ContainerType>
@@ -90,14 +90,14 @@ static void writeContainer( osgDB::OutputStream& os, ContainerType* container )
     os << os.PROPERTY("KeyFrameContainer") << (container!=NULL);
     if ( container!=NULL )
     {
-        os.writeSize(container->size()); os << os.BEGIN_BRACKET << std::endl;
+        os.writeSize(container->size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( unsigned int i=0; i<container->size(); ++i )
         {
-            os << (*container)[i].getTime() << (*container)[i].getValue() << std::endl;
+            os << (*container)[i].getTime() << (*container)[i].getValue() << osgDB::OutputStream::Endl{};
         }
         os << os.END_BRACKET;
     }
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
 }
 
 template <typename ContainerType>
@@ -107,36 +107,36 @@ static void writeContainer2( osgDB::OutputStream& os, ContainerType* container )
     os << os.PROPERTY("KeyFrameContainer") << (container!=NULL);
     if ( container!=NULL )
     {
-        os.writeSize(container->size()); os << os.BEGIN_BRACKET << std::endl;
+        os.writeSize(container->size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( unsigned int i=0; i<container->size(); ++i )
         {
             const KeyType& keyframe = (*container)[i];
             os << keyframe.getTime() << keyframe.getValue().getPosition()
                << keyframe.getValue().getControlPointIn()
-               << keyframe.getValue().getControlPointOut() << std::endl;
+               << keyframe.getValue().getControlPointOut() << osgDB::OutputStream::Endl{};
         }
         os << os.END_BRACKET;
     }
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
 }
 
 #define WRITE_CHANNEL_FUNC( NAME, CHANNEL, CONTAINER ) \
     CHANNEL* ch_##NAME = dynamic_cast<CHANNEL*>(ch); \
     if ( ch_##NAME ) { \
-        os << os.PROPERTY("Type") << std::string(#NAME) << os.BEGIN_BRACKET << std::endl; \
+        os << os.PROPERTY("Type") << std::string(#NAME) << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; \
         writeChannel( os, ch_##NAME ); \
         writeContainer<CONTAINER>( os, ch_##NAME ->getSamplerTyped()->getKeyframeContainerTyped() ); \
-        os << os.END_BRACKET << std::endl; \
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{}; \
         continue; \
     }
 
 #define WRITE_CHANNEL_FUNC2( NAME, CHANNEL, CONTAINER ) \
     CHANNEL* ch_##NAME = dynamic_cast<CHANNEL*>(ch); \
     if ( ch_##NAME ) { \
-        os << os.PROPERTY("Type") << #NAME << os.BEGIN_BRACKET << std::endl; \
+        os << os.PROPERTY("Type") << #NAME << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; \
         writeChannel( os, ch_##NAME ); \
         writeContainer2<CONTAINER>( os, ch_##NAME ->getSamplerTyped()->getKeyframeContainerTyped() ); \
-        os << os.END_BRACKET << std::endl; \
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{}; \
         continue; \
     }
 
@@ -194,7 +194,7 @@ static bool readChannels( osgDB::InputStream& is, osgAnimation::Animation& ani )
 static bool writeChannels( osgDB::OutputStream& os, const osgAnimation::Animation& ani )
 {
     const osgAnimation::ChannelList& channels = ani.getChannels();
-    os.writeSize(channels.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(channels.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osgAnimation::ChannelList::const_iterator itr=channels.begin();
           itr!=channels.end(); ++itr )
     {
@@ -225,10 +225,10 @@ static bool writeChannels( osgDB::OutputStream& os, const osgAnimation::Animatio
         WRITE_CHANNEL_FUNC2( Vec4CubicBezierChannel, osgAnimation::Vec4CubicBezierChannel,
                                                      osgAnimation::Vec4CubicBezierKeyframeContainer );
 
-        os << os.PROPERTY("Type") << std::string("UnknownChannel") << os.BEGIN_BRACKET << std::endl;
-        os << os.END_BRACKET << std::endl;
+        os << os.PROPERTY("Type") << std::string("UnknownChannel") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgAnimation/AnimationManagerBase.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/AnimationManagerBase.cpp
@@ -29,13 +29,13 @@ static bool writeAnimations( osgDB::OutputStream& os, const osgAnimation::Animat
 {
     const osgAnimation::AnimationList& animations = manager.getAnimationList();
     os.writeSize(animations.size());
-    os << os.BEGIN_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osgAnimation::AnimationList::const_iterator itr=animations.begin();
             itr!=animations.end(); ++itr )
     {
         os << itr->get();
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 struct osgAnimation_AnimationManagerBasegetnumAnimations : public osgDB::MethodObject

--- a/src/osgWrappers/serializers/osgAnimation/MorphGeometry.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/MorphGeometry.cpp
@@ -25,14 +25,14 @@ static bool readMorphTargets( osgDB::InputStream& is, osgAnimation::MorphGeometr
 static bool writeMorphTargets( osgDB::OutputStream& os, const osgAnimation::MorphGeometry& geom )
 {
     const osgAnimation::MorphGeometry::MorphTargetList& targets = geom.getMorphTargetList();
-    os.writeSize(targets.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(targets.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osgAnimation::MorphGeometry::MorphTargetList::const_iterator itr=targets.begin();
           itr!=targets.end(); ++itr )
     {
-        os << os.PROPERTY("MorphTarget") << itr->getWeight() << std::endl;
+        os << os.PROPERTY("MorphTarget") << itr->getWeight() << osgDB::OutputStream::Endl{};
         os << itr->getGeometry();
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -47,9 +47,9 @@ static bool writeMorphTargets( osgDB::OutputStream& os, const osgAnimation::Morp
         return true; \
     } \
     static bool write##ORIGINAL_PROP( osgDB::OutputStream& os, const osgAnimation::MorphGeometry& geom ) { \
-        os << os.BEGIN_BRACKET << std::endl; \
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; \
         os.writeArray( geom.get##PROP()); \
-        os << os.END_BRACKET << std::endl; \
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 ADD_ARRAYDATA_FUNCTIONS( VertexData, VertexSource )

--- a/src/osgWrappers/serializers/osgAnimation/RigGeometry.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/RigGeometry.cpp
@@ -42,7 +42,7 @@ static bool readInfluenceMap( osgDB::InputStream& is, osgAnimation::RigGeometry&
 static bool writeInfluenceMap( osgDB::OutputStream& os, const osgAnimation::RigGeometry& geom )
 {
     const osgAnimation::VertexInfluenceMap* map = geom.getInfluenceMap();
-    os.writeSize(map->size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(map->size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osgAnimation::VertexInfluenceMap::const_iterator itr=map->begin();
           itr!=map->end(); ++itr )
     {
@@ -52,16 +52,16 @@ static bool writeInfluenceMap( osgDB::OutputStream& os, const osgAnimation::RigG
 
         os << os.PROPERTY("VertexInfluence");
         os.writeWrappedString(name);
-        os.writeSize(vi.size()) ; os << os.BEGIN_BRACKET << std::endl;
+        os.writeSize(vi.size()) ; os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
 
         for ( osgAnimation::VertexInfluence::const_iterator vitr=vi.begin();
               vitr != vi.end(); ++vitr )
         {
-            os << vitr->first << vitr->second << std::endl;
+            os << vitr->first << vitr->second << osgDB::OutputStream::Endl{};
         }
-        os << os.END_BRACKET << std::endl;
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgAnimation/UpdateMatrixTransform.cpp
+++ b/src/osgWrappers/serializers/osgAnimation/UpdateMatrixTransform.cpp
@@ -27,13 +27,13 @@ static bool readStackedTransforms( osgDB::InputStream& is, osgAnimation::UpdateM
 static bool writeStackedTransforms( osgDB::OutputStream& os, const osgAnimation::UpdateMatrixTransform& obj )
 {
     const osgAnimation::StackedTransform& transform = obj.getStackedTransforms();
-    os.writeSize(transform.size()); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(transform.size()); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osgAnimation::StackedTransform::const_iterator itr=transform.begin();
           itr!=transform.end(); ++itr )
     {
         os << itr->get();
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgFX/AnisotropicLighting.cpp
+++ b/src/osgWrappers/serializers/osgFX/AnisotropicLighting.cpp
@@ -21,7 +21,7 @@ static bool readLightingMap( osgDB::InputStream& is, osgFX::AnisotropicLighting&
 static bool writeLightingMap( osgDB::OutputStream& os, const osgFX::AnisotropicLighting& effect )
 {
     os.writeWrappedString( effect.getLightingMap()->getFileName() );
-    os << std::endl; return true;
+    os << osgDB::OutputStream::Endl{}; return true;
 }
 
 REGISTER_OBJECT_WRAPPER( osgFX_AnisotropicLighting,

--- a/src/osgWrappers/serializers/osgFX/Effect.cpp
+++ b/src/osgWrappers/serializers/osgFX/Effect.cpp
@@ -17,7 +17,7 @@ static bool readSelectedTechnique( osgDB::InputStream& is, osgFX::Effect& effect
 
 static bool writeSelectedTechnique( osgDB::OutputStream& os, const osgFX::Effect& effect )
 {
-    os << effect.getSelectedTechnique() << std::endl;
+    os << effect.getSelectedTechnique() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgFX/MultiTextureControl.cpp
+++ b/src/osgWrappers/serializers/osgFX/MultiTextureControl.cpp
@@ -23,12 +23,12 @@ static bool readTextureWeights( osgDB::InputStream& is, osgFX::MultiTextureContr
 static bool writeTextureWeights( osgDB::OutputStream& os, const osgFX::MultiTextureControl& ctrl )
 {
     unsigned int size = ctrl.getNumTextureWeights();
-    os.writeSize(size); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize(size); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << ctrl.getTextureWeight(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgGA/KeySwitchMatrixManipulator.cpp
+++ b/src/osgWrappers/serializers/osgGA/KeySwitchMatrixManipulator.cpp
@@ -51,7 +51,7 @@ static bool writeKeyManipMap( osgDB::OutputStream& os, const osgGA::KeySwitchMat
     }
 
     os << activeCameraManipulatorIndex;
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
 
     for ( osgGA::KeySwitchMatrixManipulator::KeyManipMap::const_iterator itr = kmm.begin();
           itr != kmm.end();
@@ -61,7 +61,7 @@ static bool writeKeyManipMap( osgDB::OutputStream& os, const osgGA::KeySwitchMat
         os << itr->second.first;
         os.writeObject(itr->second.second.get());
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
 
     return true;
 }

--- a/src/osgWrappers/serializers/osgManipulator/CompositeDragger.cpp
+++ b/src/osgWrappers/serializers/osgManipulator/CompositeDragger.cpp
@@ -23,12 +23,12 @@ static bool readDraggers( osgDB::InputStream& is, osgManipulator::CompositeDragg
 static bool writeDraggers( osgDB::OutputStream& os, const osgManipulator::CompositeDragger& dragger )
 {
     unsigned int size = dragger.getNumDraggers();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << dragger.getDragger(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgManipulator/Dragger.cpp
+++ b/src/osgWrappers/serializers/osgManipulator/Dragger.cpp
@@ -30,7 +30,7 @@ static bool readTransformUpdating( osgDB::InputStream& is, osgManipulator::Dragg
 static bool writeTransformUpdating( osgDB::OutputStream& os, const osgManipulator::Dragger& dragger )
 {
     const osgManipulator::Dragger::DraggerCallbacks& callbacks = dragger.getDraggerCallbacks();
-    os.writeSize( callbacks.size() ); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize( callbacks.size() ); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osgManipulator::Dragger::DraggerCallbacks::const_iterator itr=callbacks.begin();
           itr!=callbacks.end(); ++itr )
     {
@@ -38,16 +38,16 @@ static bool writeTransformUpdating( osgDB::OutputStream& os, const osgManipulato
             dynamic_cast<osgManipulator::DraggerTransformCallback*>( itr->get() );
         if ( dtcb )
         {
-            os << std::string("DraggerTransformCallback") << os.BEGIN_BRACKET << std::endl;
+            os << std::string("DraggerTransformCallback") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
             os << dtcb->getTransform();
         }
         else
         {
-            os << std::string("DraggerCallback") << os.BEGIN_BRACKET << std::endl;
+            os << std::string("DraggerCallback") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         }
-        os << os.END_BRACKET << std::endl;
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -64,7 +64,7 @@ static bool readDefaultGeometry( osgDB::InputStream& is, osgManipulator::Dragger
 
 static bool writeDefaultGeometry( osgDB::OutputStream& os, const osgManipulator::Dragger& dragger )
 {
-    os << true << std::endl;
+    os << true << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgParticle/BoxPlacer.cpp
+++ b/src/osgWrappers/serializers/osgParticle/BoxPlacer.cpp
@@ -11,7 +11,7 @@
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osgParticle::BoxPlacer& obj ) { \
         const osgParticle::rangef& range = obj.get##PROP(); \
-        os << range.minimum << range.maximum << std::endl; \
+        os << range.minimum << range.maximum << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 

--- a/src/osgWrappers/serializers/osgParticle/CompositePlacer.cpp
+++ b/src/osgWrappers/serializers/osgParticle/CompositePlacer.cpp
@@ -23,12 +23,12 @@ static bool readPlacers( osgDB::InputStream& is, osgParticle::CompositePlacer& c
 static bool writePlacers( osgDB::OutputStream& os, const osgParticle::CompositePlacer& cp )
 {
     unsigned int size = cp.getNumPlacers();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << cp.getPlacer(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgParticle/DomainOperator.cpp
+++ b/src/osgWrappers/serializers/osgParticle/DomainOperator.cpp
@@ -44,7 +44,7 @@ static bool readDomains( osgDB::InputStream& is, osgParticle::DomainOperator& dp
 static bool writeDomains( osgDB::OutputStream& os, const osgParticle::DomainOperator& dp )
 {
     unsigned int size = dp.getNumDomains();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         const osgParticle::DomainOperator::Domain& domain = dp.getDomain(i);
@@ -53,35 +53,35 @@ static bool writeDomains( osgDB::OutputStream& os, const osgParticle::DomainOper
         switch (domain.type)
         {
         case osgParticle::DomainOperator::Domain::POINT_DOMAIN:
-            os << std::string("POINT") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("POINT") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         case osgParticle::DomainOperator::Domain::LINE_DOMAIN:
-            os << std::string("LINE") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("LINE") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         case osgParticle::DomainOperator::Domain::TRI_DOMAIN:
-            os << std::string("TRIANGLE") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("TRIANGLE") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         case osgParticle::DomainOperator::Domain::RECT_DOMAIN:
-            os << std::string("RECTANGLE") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("RECTANGLE") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         case osgParticle::DomainOperator::Domain::PLANE_DOMAIN:
-            os << std::string("PLANE") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("PLANE") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         case osgParticle::DomainOperator::Domain::SPHERE_DOMAIN:
-            os << std::string("SPHERE") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("SPHERE") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         case osgParticle::DomainOperator::Domain::BOX_DOMAIN:
-            os << std::string("BOX") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("BOX") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         case osgParticle::DomainOperator::Domain::DISK_DOMAIN:
-            os << std::string("DISK") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("DISK") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         default:
-            os << std::string("UNDEFINED") << os.BEGIN_BRACKET << std::endl; break;
+            os << std::string("UNDEFINED") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{}; break;
         }
 
-        os << os.PROPERTY("Plane") << domain.plane << std::endl;
-        os << os.PROPERTY("Vertices1") << domain.v1 << std::endl;
-        os << os.PROPERTY("Vertices2") << domain.v2 << std::endl;
-        os << os.PROPERTY("Vertices3") << domain.v3 << std::endl;
-        os << os.PROPERTY("Basis1") << domain.s1 << std::endl;
-        os << os.PROPERTY("Basis2") << domain.s2 << std::endl;
-        os << os.PROPERTY("Factors") << domain.r1 << domain.r2 << std::endl;
-        os << os.END_BRACKET << std::endl;
+        os << os.PROPERTY("Plane") << domain.plane << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Vertices1") << domain.v1 << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Vertices2") << domain.v2 << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Vertices3") << domain.v3 << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Basis1") << domain.s1 << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Basis2") << domain.s2 << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Factors") << domain.r1 << domain.r2 << osgDB::OutputStream::Endl{};
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgParticle/ModularProgram.cpp
+++ b/src/osgWrappers/serializers/osgParticle/ModularProgram.cpp
@@ -23,12 +23,12 @@ static bool readOperators( osgDB::InputStream& is, osgParticle::ModularProgram& 
 static bool writeOperators( osgDB::OutputStream& os, const osgParticle::ModularProgram& prog )
 {
     unsigned int size = prog.numOperators();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << prog.getOperator(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgParticle/MultiSegmentPlacer.cpp
+++ b/src/osgWrappers/serializers/osgParticle/MultiSegmentPlacer.cpp
@@ -23,13 +23,13 @@ static bool readVertices( osgDB::InputStream& is, osgParticle::MultiSegmentPlace
 static bool writeVertices( osgDB::OutputStream& os, const osgParticle::MultiSegmentPlacer& placer )
 {
     unsigned int size = placer.numVertices();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << osg::Vec3d(placer.getVertex(i));
     }
-    os << std::endl;
-    os << os.END_BRACKET << std::endl;
+    os << osgDB::OutputStream::Endl{};
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgParticle/Particle.cpp
+++ b/src/osgWrappers/serializers/osgParticle/Particle.cpp
@@ -88,34 +88,34 @@ bool readParticle( osgDB::InputStream& is, osgParticle::Particle& p )
 
 bool writeParticle( osgDB::OutputStream& os, const osgParticle::Particle& p )
 {
-    os << os.BEGIN_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
 
-    os << os.PROPERTY("Shape"); writeShapeValue( os, (int)p.getShape() ); os << std::endl;
+    os << os.PROPERTY("Shape"); writeShapeValue( os, (int)p.getShape() ); os << osgDB::OutputStream::Endl{};
 
-    os << os.PROPERTY("LifeTime") << p.getLifeTime() << std::endl;
-    os << os.PROPERTY("SizeRange") << p.getSizeRange().minimum << p.getSizeRange().maximum << std::endl;
-    os << os.PROPERTY("AlphaRange") << p.getAlphaRange().minimum << p.getAlphaRange().maximum << std::endl;
+    os << os.PROPERTY("LifeTime") << p.getLifeTime() << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("SizeRange") << p.getSizeRange().minimum << p.getSizeRange().maximum << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("AlphaRange") << p.getAlphaRange().minimum << p.getAlphaRange().maximum << osgDB::OutputStream::Endl{};
     os << os.PROPERTY("ColorRange") << osg::Vec4d(p.getColorRange().minimum)
-                                        << osg::Vec4d(p.getColorRange().maximum) << std::endl;
+                                        << osg::Vec4d(p.getColorRange().maximum) << osgDB::OutputStream::Endl{};
 
     os << os.PROPERTY("SizeInterpolator") << (p.getSizeInterpolator()!=NULL);
     if ( p.getSizeInterpolator()!=NULL )
-        os << os.BEGIN_BRACKET << std::endl << p.getSizeInterpolator() << os.END_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{} << p.getSizeInterpolator() << os.END_BRACKET << osgDB::OutputStream::Endl{};
     os << os.PROPERTY("AlphaInterpolator") << (p.getAlphaInterpolator()!=NULL);
     if ( p.getAlphaInterpolator()!=NULL )
-        os << os.BEGIN_BRACKET << std::endl << p.getAlphaInterpolator() << os.END_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{} << p.getAlphaInterpolator() << os.END_BRACKET << osgDB::OutputStream::Endl{};
     os << os.PROPERTY("ColorInterpolator") << (p.getColorInterpolator()!=NULL);
     if ( p.getColorInterpolator()!=NULL )
-        os << os.BEGIN_BRACKET << std::endl << p.getColorInterpolator() << os.END_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{} << p.getColorInterpolator() << os.END_BRACKET << osgDB::OutputStream::Endl{};
 
-    os << os.PROPERTY("Radius") << p.getRadius() << std::endl;
-    os << os.PROPERTY("Mass") << p.getMass() << std::endl;
-    os << os.PROPERTY("Position") << osg::Vec3d(p.getPosition()) << std::endl;
-    os << os.PROPERTY("Velocity") << osg::Vec3d(p.getVelocity()) << std::endl;
-    os << os.PROPERTY("Angle") << osg::Vec3d(p.getAngle()) << std::endl;
-    os << os.PROPERTY("AngularVelocity") << osg::Vec3d(p.getAngularVelocity()) << std::endl;
-    os << os.PROPERTY("TextureTile") << p.getTileS() << p.getTileT() << p.getNumTiles() << std::endl;
+    os << os.PROPERTY("Radius") << p.getRadius() << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Mass") << p.getMass() << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Position") << osg::Vec3d(p.getPosition()) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Velocity") << osg::Vec3d(p.getVelocity()) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Angle") << osg::Vec3d(p.getAngle()) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("AngularVelocity") << osg::Vec3d(p.getAngularVelocity()) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("TextureTile") << p.getTileS() << p.getTileT() << p.getNumTiles() << osgDB::OutputStream::Endl{};
 
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }

--- a/src/osgWrappers/serializers/osgParticle/ParticleEffect.cpp
+++ b/src/osgWrappers/serializers/osgParticle/ParticleEffect.cpp
@@ -21,9 +21,9 @@ static bool readParticleSystem( osgDB::InputStream& is, osgParticle::ParticleEff
 
 static bool writeParticleSystem( osgDB::OutputStream& os, const osgParticle::ParticleEffect& effect )
 {
-    os << os.BEGIN_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     os << effect.getParticleSystem();
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgParticle/ParticleSystem.cpp
+++ b/src/osgWrappers/serializers/osgParticle/ParticleSystem.cpp
@@ -26,11 +26,11 @@ static bool readDefaultBoundingBox( osgDB::InputStream& is, osgParticle::Particl
 static bool writeDefaultBoundingBox( osgDB::OutputStream& os, const osgParticle::ParticleSystem& ps )
 {
     const osg::BoundingBox& bb = ps.getDefaultBoundingBox();
-    os << os.BEGIN_BRACKET << std::endl;
-    os << os.PROPERTY("Minimum") << osg::Vec3d(bb._min) << std::endl;
-    os << os.PROPERTY("Maximum") << osg::Vec3d(bb._max) << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Minimum") << osg::Vec3d(bb._min) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Maximum") << osg::Vec3d(bb._max) << osgDB::OutputStream::Endl{};
     os << os.END_BRACKET;
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgParticle/ParticleSystemUpdater.cpp
+++ b/src/osgWrappers/serializers/osgParticle/ParticleSystemUpdater.cpp
@@ -23,12 +23,12 @@ static bool readParticleSystems( osgDB::InputStream& is, osgParticle::ParticleSy
 static bool writeParticleSystems( osgDB::OutputStream& os, const osgParticle::ParticleSystemUpdater& updater )
 {
     unsigned int size = updater.getNumParticleSystems();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << updater.getParticleSystem(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgParticle/RadialShooter.cpp
+++ b/src/osgWrappers/serializers/osgParticle/RadialShooter.cpp
@@ -11,7 +11,7 @@
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osgParticle::RadialShooter& obj ) { \
         const osgParticle::rangef& range = obj.get##PROP(); \
-        os << range.minimum << range.maximum << std::endl; \
+        os << range.minimum << range.maximum << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 
@@ -23,7 +23,7 @@
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osgParticle::RadialShooter& obj ) { \
         const osgParticle::rangev3& range = obj.get##PROP(); \
-        os << osg::Vec3d(range.minimum) << osg::Vec3d(range.maximum) << std::endl; \
+        os << osg::Vec3d(range.minimum) << osg::Vec3d(range.maximum) << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 

--- a/src/osgWrappers/serializers/osgParticle/SectorPlacer.cpp
+++ b/src/osgWrappers/serializers/osgParticle/SectorPlacer.cpp
@@ -11,7 +11,7 @@
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osgParticle::SectorPlacer& obj ) { \
         const osgParticle::rangef& range = obj.get##PROP(); \
-        os << range.minimum << range.maximum << std::endl; \
+        os << range.minimum << range.maximum << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 

--- a/src/osgWrappers/serializers/osgParticle/VariableRateCounter.cpp
+++ b/src/osgWrappers/serializers/osgParticle/VariableRateCounter.cpp
@@ -15,7 +15,7 @@ static bool readRateRange( osgDB::InputStream& is, osgParticle::VariableRateCoun
 static bool writeRateRange( osgDB::OutputStream& os, const osgParticle::VariableRateCounter& obj )
 {
     const osgParticle::rangef& range = obj.getRateRange();
-    os << range.minimum << range.maximum << std::endl;
+    os << range.minimum << range.maximum << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/AzimElevationSector.cpp
+++ b/src/osgWrappers/serializers/osgSim/AzimElevationSector.cpp
@@ -18,7 +18,7 @@ static bool writeAzimRange( osgDB::OutputStream& os, const osgSim::AzimElevation
 {
     float minAzimuth, maxAzimuth, fadeAngle;
     sector.getAzimuthRange( minAzimuth, maxAzimuth, fadeAngle );
-    os << minAzimuth << maxAzimuth << fadeAngle << std::endl;
+    os << minAzimuth << maxAzimuth << fadeAngle << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -35,7 +35,7 @@ static bool readElevationRange( osgDB::InputStream& is, osgSim::AzimElevationSec
 
 static bool writeElevationRange( osgDB::OutputStream& os, const osgSim::AzimElevationSector& sector )
 {
-    os << sector.getMinElevation() << sector.getMaxElevation() << sector.getFadeAngle() << std::endl;
+    os << sector.getMinElevation() << sector.getMaxElevation() << sector.getFadeAngle() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/AzimSector.cpp
+++ b/src/osgWrappers/serializers/osgSim/AzimSector.cpp
@@ -18,7 +18,7 @@ static bool writeAzimRange( osgDB::OutputStream& os, const osgSim::AzimSector& s
 {
     float minAzimuth, maxAzimuth, fadeAngle;
     sector.getAzimuthRange( minAzimuth, maxAzimuth, fadeAngle );
-    os << minAzimuth << maxAzimuth << fadeAngle << std::endl;
+    os << minAzimuth << maxAzimuth << fadeAngle << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/BlinkSequence.cpp
+++ b/src/osgWrappers/serializers/osgSim/BlinkSequence.cpp
@@ -25,15 +25,15 @@ static bool readPulseData( osgDB::InputStream& is, osgSim::BlinkSequence& bs )
 static bool writePulseData( osgDB::OutputStream& os, const osgSim::BlinkSequence& bs )
 {
     unsigned int size = bs.getNumPulses();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         double length = 0.0;
         osg::Vec4 color;
         bs.getPulse( i, length, color );
-        os << length << color << std::endl;
+        os << length << color << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/ConeSector.cpp
+++ b/src/osgWrappers/serializers/osgSim/ConeSector.cpp
@@ -16,7 +16,7 @@ static bool readAngle( osgDB::InputStream& is, osgSim::ConeSector& sector )
 
 static bool writeAngle( osgDB::OutputStream& os, const osgSim::ConeSector& sector )
 {
-    os << sector.getAngle() << sector.getFadeAngle() << std::endl;
+    os << sector.getAngle() << sector.getFadeAngle() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/DOFTransform.cpp
+++ b/src/osgWrappers/serializers/osgSim/DOFTransform.cpp
@@ -17,7 +17,7 @@ static bool readPutMatrix( osgDB::InputStream& is, osgSim::DOFTransform& dof )
 static bool writePutMatrix( osgDB::OutputStream& os, const osgSim::DOFTransform& dof )
 {
     osg::Matrixf put = dof.getPutMatrix();
-    os << put << std::endl;
+    os << put << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -33,7 +33,7 @@ static bool readLimitationFlags( osgDB::InputStream& is, osgSim::DOFTransform& d
 
 static bool writeLimitationFlags( osgDB::OutputStream& os, const osgSim::DOFTransform& dof )
 {
-    os << dof.getLimitationFlags() << std::endl;
+    os << dof.getLimitationFlags() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/ElevationSector.cpp
+++ b/src/osgWrappers/serializers/osgSim/ElevationSector.cpp
@@ -16,7 +16,7 @@ static bool readElevationRange( osgDB::InputStream& is, osgSim::ElevationSector&
 
 static bool writeElevationRange( osgDB::OutputStream& os, const osgSim::ElevationSector& sector )
 {
-    os << sector.getMinElevation() << sector.getMaxElevation() << sector.getFadeAngle() << std::endl;
+    os << sector.getMinElevation() << sector.getMaxElevation() << sector.getFadeAngle() << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/LightPointNode.cpp
+++ b/src/osgWrappers/serializers/osgSim/LightPointNode.cpp
@@ -46,32 +46,32 @@ static bool readLightPointList( osgDB::InputStream& is, osgSim::LightPointNode& 
 static bool writeLightPointList( osgDB::OutputStream& os, const osgSim::LightPointNode& node )
 {
     unsigned int size = node.getNumLightPoints();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         const osgSim::LightPoint& pt = node.getLightPoint(i);
-        os << os.PROPERTY("LightPoint") << os.BEGIN_BRACKET << std::endl;
-        os << os.PROPERTY("Position") << pt._position << std::endl;
-        os << os.PROPERTY("Color") << pt._color << std::endl;
+        os << os.PROPERTY("LightPoint") << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Position") << pt._position << osgDB::OutputStream::Endl{};
+        os << os.PROPERTY("Color") << pt._color << osgDB::OutputStream::Endl{};
         os << os.PROPERTY("Attributes") << pt._on << (int)pt._blendingMode
-                                            << pt._intensity << pt._radius << std::endl;
+                                            << pt._intensity << pt._radius << osgDB::OutputStream::Endl{};
         os << os.PROPERTY("Sector") << (pt._sector!=NULL);
         if ( pt._sector!=NULL )
         {
-            os << os.BEGIN_BRACKET << std::endl;
+            os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
             os.writeObject( pt._sector.get() );
-            os << os.END_BRACKET << std::endl;
+            os << os.END_BRACKET << osgDB::OutputStream::Endl{};
         }
         os << os.PROPERTY("BlinkSequence") << (pt._blinkSequence!=NULL);
         if ( pt._blinkSequence!=NULL )
         {
-            os << os.BEGIN_BRACKET << std::endl;
+            os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
             os.writeObject( pt._blinkSequence.get() );
-            os << os.END_BRACKET << std::endl;
+            os << os.END_BRACKET << osgDB::OutputStream::Endl{};
         }
-        os << os.END_BRACKET << std::endl;
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/MultiSwitch.cpp
+++ b/src/osgWrappers/serializers/osgSim/MultiSwitch.cpp
@@ -32,20 +32,20 @@ static bool readValues( osgDB::InputStream& is, osgSim::MultiSwitch& node )
 static bool writeValues( osgDB::OutputStream& os, const osgSim::MultiSwitch& node )
 {
     const osgSim::MultiSwitch::SwitchSetList& switches = node.getSwitchSetList();
-    os.writeSize( switches.size() ); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize( switches.size() ); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<switches.size(); ++i )
     {
         const osgSim::MultiSwitch::ValueList& values = node.getValueList(i);
         os << os.PROPERTY("SwitchSet"); os.writeSize( values.size() );
-        os << os.BEGIN_BRACKET << std::endl;
+        os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( osgSim::MultiSwitch::ValueList::const_iterator itr=values.begin();
               itr!=values.end(); ++itr )
         {
-            os << *itr << std::endl;
+            os << *itr << osgDB::OutputStream::Endl{};
         }
-        os << os.END_BRACKET << std::endl;
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/ObjectRecordData.cpp
+++ b/src/osgWrappers/serializers/osgSim/ObjectRecordData.cpp
@@ -21,12 +21,12 @@ static bool readData( osgDB::InputStream& is, osgSim::ObjectRecordData& data )
 
 static bool writeData( osgDB::OutputStream& os, const osgSim::ObjectRecordData& data )
 {
-    os << os.PROPERTY("Flags") << data._flags << std::endl;
-    os << os.PROPERTY("RelativePriority") << data._relativePriority << std::endl;
-    os << os.PROPERTY("Transparency") << data._transparency << std::endl;
-    os << os.PROPERTY("EffectID1") << data._effectID1 << std::endl;
-    os << os.PROPERTY("EffectID2") << data._effectID2 << std::endl;
-    os << os.PROPERTY("Significance") << data._significance << std::endl;
+    os << os.PROPERTY("Flags") << data._flags << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("RelativePriority") << data._relativePriority << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Transparency") << data._transparency << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("EffectID1") << data._effectID1 << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("EffectID2") << data._effectID2 << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Significance") << data._significance << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/ScalarBar.cpp
+++ b/src/osgWrappers/serializers/osgSim/ScalarBar.cpp
@@ -41,8 +41,8 @@ static bool readScalarsToColors( osgDB::InputStream& is, osgSim::ScalarBar& bar 
 static bool writeScalarsToColors( osgDB::OutputStream& os, const osgSim::ScalarBar& bar )
 {
     const osgSim::ScalarsToColors* stc = bar.getScalarsToColors();
-    os << os.BEGIN_BRACKET << std::endl;
-    os << os.PROPERTY("Range") << stc->getMin() << stc->getMax() << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Range") << stc->getMin() << stc->getMax() << osgDB::OutputStream::Endl{};
     os << os.PROPERTY("Colors");
 
     unsigned int colorSize = 0;
@@ -52,16 +52,16 @@ static bool writeScalarsToColors( osgDB::OutputStream& os, const osgSim::ScalarB
         const std::vector<osg::Vec4>& colors = cr->getColors();
         colorSize = colors.size();
 
-        os << true << colorSize << os.BEGIN_BRACKET << std::endl;
+        os << true << colorSize << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
         for ( unsigned int i=0; i<colorSize; ++i )
         {
-            os << colors[i] << std::endl;
+            os << colors[i] << osgDB::OutputStream::Endl{};
         }
-        os << os.END_BRACKET << std::endl;
+        os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     }
     else
-        os << false << colorSize << std::endl;
-    os << os.END_BRACKET << std::endl;
+        os << false << colorSize << osgDB::OutputStream::Endl{};
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -83,9 +83,9 @@ static bool readScalarPrinter( osgDB::InputStream& is, osgSim::ScalarBar& bar )
 
 static bool writeScalarPrinter( osgDB::OutputStream& os, const osgSim::ScalarBar& bar )
 {
-    os << os.BEGIN_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     os.writeObject( dynamic_cast<const osg::Object*>(bar.getScalarPrinter()) );
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -112,13 +112,13 @@ static bool readTextProperties( osgDB::InputStream& is, osgSim::ScalarBar& bar )
 static bool writeTextProperties( osgDB::OutputStream& os, const osgSim::ScalarBar& bar )
 {
     const osgSim::ScalarBar::TextProperties& prop = bar.getTextProperties();
-    os << os.BEGIN_BRACKET << std::endl;
-    os << os.PROPERTY("Font") << prop._fontFile << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Font") << prop._fontFile << osgDB::OutputStream::Endl{};
     os << os.PROPERTY("Resolution") << prop._fontResolution.first
-                                        << prop._fontResolution.second << std::endl;
-    os << os.PROPERTY("CharacterSize") << prop._characterSize << std::endl;
-    os << os.PROPERTY("Color") << prop._color << std::endl;
-    os << os.END_BRACKET << std::endl;
+                                        << prop._fontResolution.second << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("CharacterSize") << prop._characterSize << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("Color") << prop._color << osgDB::OutputStream::Endl{};
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/ShapeAttributeList.cpp
+++ b/src/osgWrappers/serializers/osgSim/ShapeAttributeList.cpp
@@ -45,7 +45,7 @@ static bool readAttributes( osgDB::InputStream& is, osgSim::ShapeAttributeList& 
 static bool writeAttributes( osgDB::OutputStream& os, const osgSim::ShapeAttributeList& list )
 {
     unsigned int size = list.size();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         const osgSim::ShapeAttribute& sa = list[i];
@@ -53,12 +53,12 @@ static bool writeAttributes( osgDB::OutputStream& os, const osgSim::ShapeAttribu
         os << os.PROPERTY("Type") << (int)sa.getType();
         switch ( sa.getType() )
         {
-        case osgSim::ShapeAttribute::INTEGER: os << sa.getInt() << std::endl; break;
-        case osgSim::ShapeAttribute::DOUBLE: os << sa.getDouble() << std::endl; break;
-        default: os << std::string(sa.getString()) << std::endl; break;
+        case osgSim::ShapeAttribute::INTEGER: os << sa.getInt() << osgDB::OutputStream::Endl{}; break;
+        case osgSim::ShapeAttribute::DOUBLE: os << sa.getDouble() << osgDB::OutputStream::Endl{}; break;
+        default: os << std::string(sa.getString()) << osgDB::OutputStream::Endl{}; break;
         }
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgSim/SphereSegment.cpp
+++ b/src/osgWrappers/serializers/osgSim/SphereSegment.cpp
@@ -18,7 +18,7 @@ static bool writeArea( osgDB::OutputStream& os, const osgSim::SphereSegment& sph
 {
     float azMin, azMax, elevMin, elevMax;
     sphere.getArea( azMin, azMax, elevMin, elevMax );
-    os << azMin << azMax << elevMin << elevMax << std::endl;
+    os << azMin << azMax << elevMin << elevMax << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgTerrain/CompositeLayer.cpp
+++ b/src/osgWrappers/serializers/osgTerrain/CompositeLayer.cpp
@@ -34,7 +34,7 @@ static bool readLayers( osgDB::InputStream& is, osgTerrain::CompositeLayer& laye
 static bool writeLayers( osgDB::OutputStream& os, const osgTerrain::CompositeLayer& layer )
 {
     unsigned int size = layer.getNumLayers();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         const osgTerrain::Layer* child = layer.getLayer(i);
@@ -47,10 +47,10 @@ static bool writeLayers( osgDB::OutputStream& os, const osgTerrain::CompositeLay
         else
         {
             os.writeWrappedString( layer.getCompoundName(i) );
-            os << std::endl;
+            os << osgDB::OutputStream::Endl{};
         }
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgTerrain/GeometryTechnique.cpp
+++ b/src/osgWrappers/serializers/osgTerrain/GeometryTechnique.cpp
@@ -24,12 +24,12 @@ static bool readFilterMatrix( osgDB::InputStream& is, osgTerrain::GeometryTechni
 static bool writeFilterMatrix( osgDB::OutputStream& os, const osgTerrain::GeometryTechnique& tech )
 {
     const osg::Matrix3& matrix = tech.getFilterMatrix();
-    os << os.BEGIN_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( int r=0; r<3; ++r )
     {
-        os << matrix(r, 0) << matrix(r, 1) << matrix(r, 2) << std::endl;
+        os << matrix(r, 0) << matrix(r, 1) << matrix(r, 2) << osgDB::OutputStream::Endl{};
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgTerrain/ImageLayer.cpp
+++ b/src/osgWrappers/serializers/osgTerrain/ImageLayer.cpp
@@ -35,9 +35,9 @@ static bool writeImage( osgDB::OutputStream& os, const osgTerrain::ImageLayer& i
 {
     const osg::Image* image = il.getImage();
 
-    if(!os.isBinary()) os << os.BEGIN_BRACKET << std::endl;
+    if(!os.isBinary()) os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     os.writeImage(image);
-    if(!os.isBinary()) os << os.END_BRACKET << std::endl;
+    if(!os.isBinary()) os << os.END_BRACKET << osgDB::OutputStream::Endl{};
 
     return true;
 }

--- a/src/osgWrappers/serializers/osgTerrain/Layer.cpp
+++ b/src/osgWrappers/serializers/osgTerrain/Layer.cpp
@@ -36,18 +36,18 @@ static bool writeValidDataOperator( osgDB::OutputStream& os, const osgTerrain::L
     const osgTerrain::NoDataValue* ndv = dynamic_cast<const osgTerrain::NoDataValue*>( layer.getValidDataOperator() );
     if ( ndv )
     {
-        os << (unsigned int)1 << ndv->getValue() << std::endl;
+        os << (unsigned int)1 << ndv->getValue() << osgDB::OutputStream::Endl{};
         return true;
     }
 
     const osgTerrain::ValidRange* vr = dynamic_cast<const osgTerrain::ValidRange*>( layer.getValidDataOperator() );
     if ( vr )
     {
-        os << (unsigned int)2 << vr->getMinValue() << vr->getMaxValue() << std::endl;
+        os << (unsigned int)2 << vr->getMinValue() << vr->getMaxValue() << osgDB::OutputStream::Endl{};
         return true;
     }
 
-    os << (unsigned int)0 << std::endl;
+    os << (unsigned int)0 << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgTerrain/TerrainTile.cpp
+++ b/src/osgWrappers/serializers/osgTerrain/TerrainTile.cpp
@@ -20,7 +20,7 @@ static bool readTileID( osgDB::InputStream& is, osgTerrain::TerrainTile& tile )
 static bool writeTileID( osgDB::OutputStream& os, const osgTerrain::TerrainTile& tile )
 {
     const osgTerrain::TileID& id = tile.getTileID();
-    os << id.level << id.x << id.y << std::endl;
+    os << id.level << id.x << id.y << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -51,12 +51,12 @@ static bool writeColorLayers( osgDB::OutputStream& os, const osgTerrain::Terrain
         if (tile.getColorLayer(i)) ++numValidLayers;
     }
 
-    os << numValidLayers << os.BEGIN_BRACKET << std::endl;
+    os << numValidLayers << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<tile.getNumColorLayers(); ++i )
     {
         if (tile.getColorLayer(i)) os << os.PROPERTY("Layer") << i << tile.getColorLayer(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgText/Text.cpp
+++ b/src/osgWrappers/serializers/osgText/Text.cpp
@@ -19,7 +19,7 @@ static bool readBackdropOffset( osgDB::InputStream& is, osgText::Text& text )
 static bool writeBackdropOffset( osgDB::OutputStream& os, const osgText::Text& text )
 {
     os << text.getBackdropHorizontalOffset()
-       << text.getBackdropVerticalOffset() << std::endl;
+       << text.getBackdropVerticalOffset() << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -44,12 +44,12 @@ static bool readColorGradientCorners( osgDB::InputStream& is, osgText::Text& tex
 
 static bool writeColorGradientCorners( osgDB::OutputStream& os, const osgText::Text& text )
 {
-    os << os.BEGIN_BRACKET << std::endl;
-    os << os.PROPERTY("TopLeft") << osg::Vec4d(text.getColorGradientTopLeft()) << std::endl;
-    os << os.PROPERTY("BottomLeft") << osg::Vec4d(text.getColorGradientBottomLeft()) << std::endl;
-    os << os.PROPERTY("BottomRight") << osg::Vec4d(text.getColorGradientBottomRight()) << std::endl;
-    os << os.PROPERTY("TopRight") << osg::Vec4d(text.getColorGradientTopRight()) << std::endl;
-    os << os.END_BRACKET << std::endl;
+    os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("TopLeft") << osg::Vec4d(text.getColorGradientTopLeft()) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("BottomLeft") << osg::Vec4d(text.getColorGradientBottomLeft()) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("BottomRight") << osg::Vec4d(text.getColorGradientBottomRight()) << osgDB::OutputStream::Endl{};
+    os << os.PROPERTY("TopRight") << osg::Vec4d(text.getColorGradientTopRight()) << osgDB::OutputStream::Endl{};
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgText/TextBase.cpp
+++ b/src/osgWrappers/serializers/osgText/TextBase.cpp
@@ -20,7 +20,7 @@ static bool readFont( osgDB::InputStream& is, osgText::TextBase& text )
 static bool writeFont( osgDB::OutputStream& os, const osgText::TextBase& text )
 {
     os.writeWrappedString( text.getFont()->getFileName() );
-    os << std::endl;
+    os << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -39,7 +39,7 @@ static bool readFontSize( osgDB::InputStream& is, osgText::TextBase& text )
 
 static bool writeFontSize( osgDB::OutputStream& os, const osgText::TextBase& text )
 {
-    os << text.getFontWidth() << text.getFontHeight() << std::endl;
+    os << text.getFontWidth() << text.getFontHeight() << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -58,7 +58,7 @@ static bool readCharacterSize( osgDB::InputStream& is, osgText::TextBase& text )
 
 static bool writeCharacterSize( osgDB::OutputStream& os, const osgText::TextBase& text )
 {
-    os << text.getCharacterHeight() << text.getCharacterAspectRatio() << std::endl;
+    os << text.getCharacterHeight() << text.getCharacterAspectRatio() << osgDB::OutputStream::Endl{};
     return true;
 }
 
@@ -115,7 +115,7 @@ static bool writeText( osgDB::OutputStream& os, const osgText::TextBase& text )
             acString += (char)(*itr);
         }
         os.writeWrappedString( acString );
-        os << std::endl;
+        os << osgDB::OutputStream::Endl{};
     }
     else
     {

--- a/src/osgWrappers/serializers/osgVolume/CompositeLayer.cpp
+++ b/src/osgWrappers/serializers/osgVolume/CompositeLayer.cpp
@@ -23,12 +23,12 @@ static bool readLayers( osgDB::InputStream& is, osgVolume::CompositeLayer& layer
 static bool writeLayers( osgDB::OutputStream& os, const osgVolume::CompositeLayer& layer )
 {
     unsigned int size = layer.getNumLayers();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << layer.getLayer(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgVolume/CompositeProperty.cpp
+++ b/src/osgWrappers/serializers/osgVolume/CompositeProperty.cpp
@@ -23,12 +23,12 @@ static bool readProperties( osgDB::InputStream& is, osgVolume::CompositeProperty
 static bool writeProperties( osgDB::OutputStream& os, const osgVolume::CompositeProperty& prop )
 {
     unsigned int size = prop.getNumProperties();
-    os << size << os.BEGIN_BRACKET << std::endl;
+    os << size << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( unsigned int i=0; i<size; ++i )
     {
         os << prop.getProperty(i);
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgVolume/ImageDetails.cpp
+++ b/src/osgWrappers/serializers/osgVolume/ImageDetails.cpp
@@ -17,7 +17,7 @@ static bool readMatrix( osgDB::InputStream& is, osgVolume::ImageDetails& details
 
 static bool writeMatrix( osgDB::OutputStream& os, const osgVolume::ImageDetails& details )
 {
-    os << *(details.getMatrix()) << std::endl;
+    os << *(details.getMatrix()) << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgVolume/Layer.cpp
+++ b/src/osgWrappers/serializers/osgVolume/Layer.cpp
@@ -11,7 +11,7 @@
         return true; \
     } \
     static bool write##PROP( osgDB::OutputStream& os, const osgVolume::Layer& layer ) { \
-        os << GLENUM(layer.get##PROP()) << std::endl; \
+        os << GLENUM(layer.get##PROP()) << osgDB::OutputStream::Endl{}; \
         return true; \
     }
 

--- a/src/osgWrappers/serializers/osgVolume/Locator.cpp
+++ b/src/osgWrappers/serializers/osgVolume/Locator.cpp
@@ -23,13 +23,13 @@ static bool readLocatorCallbacks( osgDB::InputStream& is, osgVolume::Locator& lo
 static bool writeLocatorCallbacks( osgDB::OutputStream& os, const osgVolume::Locator& locator )
 {
     const osgVolume::Locator::LocatorCallbacks& callbacks = locator.getLocatorCallbacks();
-    os.writeSize( callbacks.size() ); os << os.BEGIN_BRACKET << std::endl;
+    os.writeSize( callbacks.size() ); os << os.BEGIN_BRACKET << osgDB::OutputStream::Endl{};
     for ( osgVolume::Locator::LocatorCallbacks::const_iterator itr=callbacks.begin();
           itr!=callbacks.end(); ++itr )
     {
         os << itr->get();
     }
-    os << os.END_BRACKET << std::endl;
+    os << os.END_BRACKET << osgDB::OutputStream::Endl{};
     return true;
 }
 

--- a/src/osgWrappers/serializers/osgVolume/VolumeTile.cpp
+++ b/src/osgWrappers/serializers/osgVolume/VolumeTile.cpp
@@ -18,7 +18,7 @@ static bool readTileID( osgDB::InputStream& is, osgVolume::VolumeTile& tile )
 static bool writeTileID( osgDB::OutputStream& os, const osgVolume::VolumeTile& tile )
 {
     const osgVolume::TileID& id = tile.getTileID();
-    os << id.level << id.x << id.y << id.z << std::endl;
+    os << id.level << id.x << id.y << id.z << osgDB::OutputStream::Endl{};
     return true;
 }
 


### PR DESCRIPTION
Relying on the address of `std::endl` is a std library specific behaviour. For example in libc++ it's inline function so it may have many addresses depending on the translation unit. Basically [this](https://github.com/OpenMW/osg/blob/68c5c573d47766507bfb191e0c8d213b1997ad20/include/osgDB/StreamOperator#L73) code from the `isEndl` function does not work as you could expect. In different translation units it will be evaluated into true or false which makes this function unpredictable and leads to broken behaviour. For example to failed tests in openmw which [compare](https://gitlab.com/OpenMW/openmw/-/blob/e6f64f5e71db6fe76431f269aca9f8deb0938f5d/apps/openmw_test_suite/nifosg/testnifloader.cpp#L74-108) serialized `osg::Node` into `osgt` format.