### PR TITLE
Erase empty object sets

### DIFF
--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -272,6 +272,7 @@ class OSG_EXPORT GLBufferObject : public GraphicsObject
 };
 
 typedef std::list< ref_ptr<GLBufferObject> > GLBufferObjectList;
+typedef std::vector<ref_ptr<GLBufferObject>> GLBufferObjectVector;
 
 class OSG_EXPORT GLBufferObjectSet : public Referenced
 {
@@ -322,7 +323,7 @@ class OSG_EXPORT GLBufferObjectSet : public Referenced
         BufferObjectProfile     _profile;
         unsigned int            _numOfGLBufferObjects;
         GLBufferObjectList      _orphanedGLBufferObjects;
-        GLBufferObjectList      _pendingOrphanedGLBufferObjects;
+        GLBufferObjectVector    _pendingOrphanedGLBufferObjects;
 
         GLBufferObject*         _head;
         GLBufferObject*         _tail;

--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -368,6 +368,8 @@ class OSG_EXPORT GLBufferObjectManager : public GraphicsObjectManager
         void reportStats(std::ostream& out);
         void recomputeStats(std::ostream& out) const;
 
+        void reportStats(unsigned frameNumber, Stats& stats) const override;
+
         unsigned int& getFrameNumber() { return _frameNumber; }
         unsigned int& getNumberFrames() { return _numFrames; }
 

--- a/include/osg/BufferObject
+++ b/include/osg/BufferObject
@@ -323,6 +323,7 @@ class OSG_EXPORT GLBufferObjectSet : public Referenced
         BufferObjectProfile     _profile;
         unsigned int            _numOfGLBufferObjects;
         GLBufferObjectList      _orphanedGLBufferObjects;
+        OpenThreads::Atomic     _pendingOrphanedGLBufferObjectsSize;
         GLBufferObjectVector    _pendingOrphanedGLBufferObjects;
 
         GLBufferObject*         _head;

--- a/include/osg/ContextData
+++ b/include/osg/ContextData
@@ -14,9 +14,14 @@
 #ifndef OSG_CONTEXTDATA
 #define OSG_CONTEXTDATA 1
 
+#include <osg/GLObjects>
 #include <osg/GraphicsContext>
 
 namespace osg {
+
+class ContextData;
+
+typedef std::map<unsigned int, osg::ref_ptr<ContextData> > ContextDataMap;
 
 class OSG_EXPORT ContextData : public GraphicsObjectManager
 {
@@ -72,6 +77,8 @@ class OSG_EXPORT ContextData : public GraphicsObjectManager
         virtual void resetStats();
         virtual void reportStats(std::ostream& out);
         virtual void recomputeStats(std::ostream& out) const;
+
+        void reportStats(unsigned frameNumber, Stats& stats) const override;
 
         /** Flush all deleted OpenGL objects within the specified availableTime.
         * Note, must be called from a thread which has current the graphics context associated with contextID. */
@@ -129,6 +136,8 @@ class OSG_EXPORT ContextData : public GraphicsObjectManager
 
         /** Unregister a GraphicsContext.*/
         static void unregisterGraphicsContext(GraphicsContext* gc);
+
+        static ContextDataMap getContextDataMap();
 
     protected:
         virtual ~ContextData();

--- a/include/osg/GLObjects
+++ b/include/osg/GLObjects
@@ -23,6 +23,7 @@ namespace osg {
 
 // forward declare
 class FrameStamp;
+class Stats;
 
 /** Flush all deleted OpenGL objects within the specified availableTime.
   * Note, must be called from a thread which has current the graphics context associated with contextID. */
@@ -66,6 +67,8 @@ class OSG_EXPORT GraphicsObjectManager : public osg::Referenced
         virtual void resetStats() {}
         virtual void reportStats(std::ostream& /*out*/)  {}
         virtual void recomputeStats(std::ostream& /*out*/) const  {}
+
+        virtual void reportStats(unsigned frameNumber, Stats& stats) const {}
 
 
         /** Flush all deleted OpenGL objects within the specified availableTime.
@@ -117,11 +120,13 @@ public:
     /** implementation of the actual deletion of an GL object - subclasses from GLObjectManager must implement the appropriate GL calls.*/
     virtual void deleteGLObject(GLuint globj) = 0;
 
+    void reportStats(unsigned frameNumber, Stats& stats) const override;
+
 protected:
     virtual ~GLObjectManager();
 
     typedef std::list<GLuint> GLObjectHandleList;
-    OpenThreads::Mutex  _mutex;
+    mutable OpenThreads::Mutex  _mutex;
     GLObjectHandleList _deleteGLObjectHandles;
 
 };

--- a/include/osg/Texture
+++ b/include/osg/Texture
@@ -1177,6 +1177,7 @@ protected:
     Texture::TextureProfile     _profile;
     unsigned int                _numOfTextureObjects;
     Texture::TextureObjectList  _orphanedTextureObjects;
+    OpenThreads::Atomic         _pendingOrphanedTextureObjectsSize;
     TextureObjectVector         _pendingOrphanedTextureObjects;
 
     Texture::TextureObject*     _head;

--- a/include/osg/Texture
+++ b/include/osg/Texture
@@ -1232,6 +1232,8 @@ public:
     void recomputeStats(std::ostream& out) const;
     bool checkConsistency() const;
 
+    void reportStats(unsigned frameNumber, Stats& stats) const override;
+
     unsigned int& getFrameNumber() { return _frameNumber; }
     unsigned int& getNumberFrames() { return _numFrames; }
 

--- a/include/osg/Texture
+++ b/include/osg/Texture
@@ -1166,6 +1166,7 @@ public:
     unsigned int getNumPendingOrphans() const { return static_cast<unsigned int>(_pendingOrphanedTextureObjects.size()); }
 
 protected:
+    typedef std::vector<ref_ptr<Texture::TextureObject>> TextureObjectVector;
 
     virtual ~TextureObjectSet();
 
@@ -1176,7 +1177,7 @@ protected:
     Texture::TextureProfile     _profile;
     unsigned int                _numOfTextureObjects;
     Texture::TextureObjectList  _orphanedTextureObjects;
-    Texture::TextureObjectList  _pendingOrphanedTextureObjects;
+    TextureObjectVector         _pendingOrphanedTextureObjects;
 
     Texture::TextureObject*     _head;
     Texture::TextureObject*     _tail;

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -365,7 +365,7 @@ void GLBufferObjectSet::handlePendingOrphandedGLBufferObjects()
 
     unsigned int numOrphaned = _pendingOrphanedGLBufferObjects.size();
 
-    for(GLBufferObjectList::iterator itr = _pendingOrphanedGLBufferObjects.begin();
+    for(GLBufferObjectVector::iterator itr = _pendingOrphanedGLBufferObjects.begin();
         itr != _pendingOrphanedGLBufferObjects.end();
         ++itr)
     {

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -38,6 +38,19 @@
 
 using namespace osg;
 
+namespace
+{
+
+template <class Iterator, class Map>
+Iterator eraseIfEmpty(Iterator it, Map& map)
+{
+    if (it->second->getNumOfGLBufferObjects() == 0)
+        return map.erase(it);
+    return ++it;
+}
+
+}
+
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // GLBufferObject::BufferEntry
@@ -937,10 +950,10 @@ void GLBufferObjectManager::deleteAllGLObjects()
     ElapsedTime elapsedTime(&(getDeleteTime()));
 
     for(GLBufferObjectSetMap::iterator itr = _glBufferObjectSetMap.begin();
-        itr != _glBufferObjectSetMap.end();
-        ++itr)
+        itr != _glBufferObjectSetMap.end();)
     {
         (*itr).second->deleteAllGLBufferObjects();
+        itr = eraseIfEmpty(itr, _glBufferObjectSetMap);
     }
 }
 
@@ -952,6 +965,7 @@ void GLBufferObjectManager::discardAllGLObjects()
     {
         (*itr).second->discardAllGLBufferObjects();
     }
+    _glBufferObjectSetMap.clear();
 }
 
 void GLBufferObjectManager::flushAllDeletedGLObjects()
@@ -959,20 +973,20 @@ void GLBufferObjectManager::flushAllDeletedGLObjects()
     ElapsedTime elapsedTime(&(getDeleteTime()));
 
     for(GLBufferObjectSetMap::iterator itr = _glBufferObjectSetMap.begin();
-        itr != _glBufferObjectSetMap.end();
-        ++itr)
+        itr != _glBufferObjectSetMap.end();)
     {
         (*itr).second->flushAllDeletedGLBufferObjects();
+        itr = eraseIfEmpty(itr, _glBufferObjectSetMap);
     }
 }
 
 void GLBufferObjectManager::discardAllDeletedGLObjects()
 {
     for(GLBufferObjectSetMap::iterator itr = _glBufferObjectSetMap.begin();
-        itr != _glBufferObjectSetMap.end();
-        ++itr)
+        itr != _glBufferObjectSetMap.end();)
     {
         (*itr).second->discardAllDeletedGLBufferObjects();
+        itr = eraseIfEmpty(itr, _glBufferObjectSetMap);
     }
 }
 
@@ -981,10 +995,10 @@ void GLBufferObjectManager::flushDeletedGLObjects(double currentTime, double& av
     ElapsedTime elapsedTime(&(getDeleteTime()));
 
     for(GLBufferObjectSetMap::iterator itr = _glBufferObjectSetMap.begin();
-        (itr != _glBufferObjectSetMap.end()) && (availableTime > 0.0);
-        ++itr)
+        (itr != _glBufferObjectSetMap.end()) && (availableTime > 0.0);)
     {
         (*itr).second->flushDeletedGLBufferObjects(currentTime, availableTime);
+        itr = eraseIfEmpty(itr, _glBufferObjectSetMap);
     }
 }
 

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -392,11 +392,8 @@ void GLBufferObjectSet::deleteAllGLBufferObjects()
 
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedGLBufferObjects.empty())
-        {
-            // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
-            handlePendingOrphandedGLBufferObjects();
-        }
+        // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
+        handlePendingOrphandedGLBufferObjects();
     }
 
     CHECK_CONSISTENCY
@@ -471,11 +468,8 @@ void GLBufferObjectSet::flushAllDeletedGLBufferObjects()
 {
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedGLBufferObjects.empty())
-        {
-            // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
-            handlePendingOrphandedGLBufferObjects();
-        }
+        // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
+        handlePendingOrphandedGLBufferObjects();
     }
 
     for(GLBufferObjectList::iterator itr = _orphanedGLBufferObjects.begin();
@@ -503,11 +497,8 @@ void GLBufferObjectSet::discardAllDeletedGLBufferObjects()
     // clean up the pending orphans.
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedGLBufferObjects.empty())
-        {
-            // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
-            handlePendingOrphandedGLBufferObjects();
-        }
+        // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
+        handlePendingOrphandedGLBufferObjects();
     }
 
     unsigned int numDiscarded = _orphanedGLBufferObjects.size();
@@ -530,11 +521,8 @@ void GLBufferObjectSet::flushDeletedGLBufferObjects(double /*currentTime*/, doub
 {
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedGLBufferObjects.empty())
-        {
-            // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
-            handlePendingOrphandedGLBufferObjects();
-        }
+        // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
+        handlePendingOrphandedGLBufferObjects();
     }
 
     if (_parent->getCurrGLBufferObjectPoolSize()<=_parent->getMaxGLBufferObjectPoolSize())
@@ -588,11 +576,8 @@ bool GLBufferObjectSet::makeSpace(unsigned int& size)
 {
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedGLBufferObjects.empty())
-        {
-            // OSG_NOTICE<<"GLBufferSet::::makeSpace(..) handling orphans"<<std::endl;
-            handlePendingOrphandedGLBufferObjects();
-        }
+        // OSG_NOTICE<<"GLBufferSet::::makeSpace(..) handling orphans"<<std::endl;
+        handlePendingOrphandedGLBufferObjects();
     }
 
     if (!_orphanedGLBufferObjects.empty())

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -382,6 +382,7 @@ void GLBufferObjectSet::handlePendingOrphandedGLBufferObjects()
     _parent->getNumberActiveGLBufferObjects() -= numOrphaned;
 
     _pendingOrphanedGLBufferObjects.clear();
+    _pendingOrphanedGLBufferObjectsSize.exchange(0);
 
     CHECK_CONSISTENCY
 }
@@ -390,6 +391,7 @@ void GLBufferObjectSet::deleteAllGLBufferObjects()
 {
     // OSG_NOTICE<<"GLBufferObjectSet::deleteAllGLBufferObjects()"<<std::endl;
 
+    if (_pendingOrphanedGLBufferObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
@@ -466,6 +468,7 @@ void GLBufferObjectSet::discardAllGLBufferObjects()
 
 void GLBufferObjectSet::flushAllDeletedGLBufferObjects()
 {
+    if (_pendingOrphanedGLBufferObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
@@ -495,6 +498,7 @@ void GLBufferObjectSet::discardAllDeletedGLBufferObjects()
     // OSG_NOTICE<<"GLBufferObjectSet::discardAllDeletedGLBufferObjects()"<<std::endl;
 
     // clean up the pending orphans.
+    if (_pendingOrphanedGLBufferObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
@@ -519,6 +523,7 @@ void GLBufferObjectSet::discardAllDeletedGLBufferObjects()
 
 void GLBufferObjectSet::flushDeletedGLBufferObjects(double /*currentTime*/, double& availableTime)
 {
+    if (_pendingOrphanedGLBufferObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"GLBufferObjectSet::flushDeletedGLBufferObjects(..) handling orphans"<<std::endl;
@@ -794,6 +799,7 @@ void GLBufferObjectSet::orphan(GLBufferObject* to)
     // list.  This double buffered approach to handling orphaned TO's is used
     // to avoid having to mutex the process of appling active TO's.
     _pendingOrphanedGLBufferObjects.push_back(to);
+    ++_pendingOrphanedGLBufferObjectsSize;
 }
 
 void GLBufferObjectSet::remove(GLBufferObject* to)

--- a/src/osg/BufferObject.cpp
+++ b/src/osg/BufferObject.cpp
@@ -25,6 +25,7 @@
 #include <osg/PrimitiveSet>
 #include <osg/Array>
 #include <osg/ContextData>
+#include <osg/Stats>
 
 #include <OpenThreads/ScopedLock>
 #include <OpenThreads/Mutex>
@@ -1049,6 +1050,11 @@ void GLBufferObjectManager::recomputeStats(std::ostream& out) const
     }
     out<<"   numObjectsInLists="<<numObjectsInLists<<", numActive="<<numActive<<", numOrphans="<<numOrphans<<" currentSize="<<currentSize<<std::endl;
     out<<"   getMaxGLBufferObjectPoolSize()="<<getMaxGLBufferObjectPoolSize()<<" current/max size = "<<double(currentSize)/double(getMaxGLBufferObjectPoolSize())<<std::endl;
+}
+
+void GLBufferObjectManager::reportStats(unsigned frameNumber, Stats& stats) const
+{
+    stats.setAttribute(frameNumber, "GLBufferObjectManager" + std::to_string(_contextID), static_cast<double>(_glBufferObjectSetMap.size()));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/osg/ContextData.cpp
+++ b/src/osg/ContextData.cpp
@@ -19,7 +19,7 @@
 using namespace osg;
 
 
-typedef std::map<unsigned int, osg::ref_ptr<ContextData> >  ContextIDMap;
+typedef ContextDataMap ContextIDMap;
 static ContextIDMap s_contextIDMap;
 static OpenThreads::ReentrantMutex s_contextIDMapMutex;
 static ContextData::GraphicsContexts s_registeredContexts;
@@ -79,6 +79,12 @@ void ContextData::recomputeStats(std::ostream& out) const
     }
 }
 
+void ContextData::reportStats(unsigned frameNumber, Stats& stats) const
+{
+    for (ManagerMap::const_iterator it = _managerMap.begin(); it != _managerMap.end(); ++it)
+        if (osg::GraphicsObjectManager* const v = dynamic_cast<osg::GraphicsObjectManager*>(it->second.get()))
+            v->reportStats(frameNumber, stats);
+}
 
 void ContextData::flushDeletedGLObjects(double currentTime, double& availableTime)
 {
@@ -333,4 +339,10 @@ GraphicsContext* ContextData::getCompileContext(unsigned int contextID)
     ContextIDMap::iterator itr = s_contextIDMap.find(contextID);
     if (itr != s_contextIDMap.end()) return itr->second->getCompileContext();
     else return 0;
+}
+
+ContextDataMap ContextData::getContextDataMap()
+{
+    OpenThreads::ScopedLock<OpenThreads::Mutex> lock(s_contextIDMapMutex);
+    return s_contextIDMap;
 }

--- a/src/osg/Drawable.cpp
+++ b/src/osg/Drawable.cpp
@@ -188,6 +188,16 @@ public:
     #endif
     }
 
+    void reportStats(unsigned frameNumber, Stats& stats) const override
+    {
+        const std::size_t size = [&](){
+            const OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex_deletedDisplayListCache);
+            return _displayListMap.size();
+        }();
+
+        stats.setAttribute(frameNumber, "DisplayListManager" + std::to_string(_contextID), static_cast<double>(size));
+    }
+
 protected:
 
     int _numberDrawablesReusedLastInLastFrame;
@@ -195,7 +205,7 @@ protected:
     int _numberDeletedDrawablesInLastFrame;
 
     typedef std::multimap<unsigned int,GLuint> DisplayListMap;
-    OpenThreads::Mutex _mutex_deletedDisplayListCache;
+    mutable OpenThreads::Mutex _mutex_deletedDisplayListCache;
     DisplayListMap _displayListMap;
 
 };

--- a/src/osg/GLObjects.cpp
+++ b/src/osg/GLObjects.cpp
@@ -146,3 +146,13 @@ GLuint GLObjectManager::createGLObject()
     OSG_INFO<<"void "<<_name<<"::createGLObject() : Not Implemented"<<std::endl;
     return 0;
 }
+
+void GLObjectManager::reportStats(unsigned frameNumber, Stats& stats) const
+{
+    const std::size_t size = [&](){
+        const OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
+        return _deleteGLObjectHandles.size();
+    }();
+
+    stats.setAttribute(frameNumber, _name + std::to_string(_contextID), static_cast<double>(size));
+}

--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -530,7 +530,7 @@ void TextureObjectSet::handlePendingOrphandedTextureObjects()
 
     unsigned int numOrphaned = _pendingOrphanedTextureObjects.size();
 
-    for(Texture::TextureObjectList::iterator itr = _pendingOrphanedTextureObjects.begin();
+    for(TextureObjectVector::iterator itr = _pendingOrphanedTextureObjects.begin();
         itr != _pendingOrphanedTextureObjects.end();
         ++itr)
     {

--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -60,6 +60,17 @@
     #define CHECK_CONSISTENCY
 #endif
 
+namespace {
+    template <class Iterator, class Map>
+    Iterator eraseIfEmpty(Iterator it, Map& map)
+    {
+        if (it->second->getNumOfTextureObjects() == 0)
+            return map.erase(it);
+        return ++it;
+    }
+}
+
+
 namespace osg {
 
 ApplicationUsageProxy Texture_e0(ApplicationUsage::ENVIRONMENTAL_VARIABLE,"OSG_MAX_TEXTURE_SIZE","Set the maximum size of textures.");
@@ -1153,10 +1164,10 @@ void TextureObjectManager::handlePendingOrphandedTextureObjects()
 void TextureObjectManager::deleteAllGLObjects()
 {
     for(TextureSetMap::iterator itr = _textureSetMap.begin();
-        itr != _textureSetMap.end();
-        ++itr)
+        itr != _textureSetMap.end();)
     {
         (*itr).second->deleteAllTextureObjects();
+        itr = eraseIfEmpty(itr, _textureSetMap);
     }
 }
 
@@ -1168,35 +1179,36 @@ void TextureObjectManager::discardAllGLObjects()
     {
         (*itr).second->discardAllTextureObjects();
     }
+    _textureSetMap.clear();
 }
 
 void TextureObjectManager::flushAllDeletedGLObjects()
 {
     for(TextureSetMap::iterator itr = _textureSetMap.begin();
-        itr != _textureSetMap.end();
-        ++itr)
+        itr != _textureSetMap.end();)
     {
         (*itr).second->flushAllDeletedTextureObjects();
+        itr = eraseIfEmpty(itr, _textureSetMap);
     }
 }
 
 void TextureObjectManager::discardAllDeletedGLObjects()
 {
     for(TextureSetMap::iterator itr = _textureSetMap.begin();
-        itr != _textureSetMap.end();
-        ++itr)
+        itr != _textureSetMap.end();)
     {
         (*itr).second->discardAllDeletedTextureObjects();
+        itr = eraseIfEmpty(itr, _textureSetMap);
     }
 }
 
 void TextureObjectManager::flushDeletedGLObjects(double currentTime, double& availableTime)
 {
     for(TextureSetMap::iterator itr = _textureSetMap.begin();
-        (itr != _textureSetMap.end()) && (availableTime > 0.0);
-        ++itr)
+        (itr != _textureSetMap.end()) && (availableTime > 0.0);)
     {
         (*itr).second->flushDeletedTextureObjects(currentTime, availableTime);
+        itr = eraseIfEmpty(itr, _textureSetMap);
     }
 }
 

--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -558,11 +558,8 @@ void TextureObjectSet::deleteAllTextureObjects()
 
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedTextureObjects.empty())
-        {
-            // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
-            handlePendingOrphandedTextureObjects();
-        }
+        // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
+        handlePendingOrphandedTextureObjects();
     }
 
     CHECK_CONSISTENCY
@@ -638,11 +635,8 @@ void TextureObjectSet::flushAllDeletedTextureObjects()
     // OSG_NOTICE<<"TextureObjectSet::flushAllDeletedTextureObjects()"<<std::endl;
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedTextureObjects.empty())
-        {
-            // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
-            handlePendingOrphandedTextureObjects();
-        }
+        // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
+        handlePendingOrphandedTextureObjects();
     }
 
     for(Texture::TextureObjectList::iterator itr = _orphanedTextureObjects.begin();
@@ -674,11 +668,8 @@ void TextureObjectSet::discardAllDeletedTextureObjects()
     // clean up the pending orphans.
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedTextureObjects.empty())
-        {
-            // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
-            handlePendingOrphandedTextureObjects();
-        }
+        // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
+        handlePendingOrphandedTextureObjects();
     }
 
     unsigned int numDiscarded = _orphanedTextureObjects.size();
@@ -702,11 +693,8 @@ void TextureObjectSet::flushDeletedTextureObjects(double /*currentTime*/, double
 
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedTextureObjects.empty())
-        {
-            // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
-            handlePendingOrphandedTextureObjects();
-        }
+        // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
+        handlePendingOrphandedTextureObjects();
     }
 
     if (_profile._size!=0 && _parent->getCurrTexturePoolSize()<=_parent->getMaxTexturePoolSize())
@@ -770,11 +758,8 @@ bool TextureObjectSet::makeSpace(unsigned int& size)
 {
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
-        if (!_pendingOrphanedTextureObjects.empty())
-        {
-            // OSG_NOTICE<<"TextureObjectSet::TextureObjectSet::makeSpace(..) handling orphans"<<std::endl;
-            handlePendingOrphandedTextureObjects();
-        }
+        // OSG_NOTICE<<"TextureObjectSet::TextureObjectSet::makeSpace(..) handling orphans"<<std::endl;
+        handlePendingOrphandedTextureObjects();
     }
 
     if (!_orphanedTextureObjects.empty())

--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -547,6 +547,7 @@ void TextureObjectSet::handlePendingOrphandedTextureObjects()
     _parent->getNumberActiveTextureObjects() -= numOrphaned;
 
     _pendingOrphanedTextureObjects.clear();
+    _pendingOrphanedTextureObjectsSize.exchange(0);
 
     CHECK_CONSISTENCY
 }
@@ -556,6 +557,7 @@ void TextureObjectSet::deleteAllTextureObjects()
 {
     // OSG_NOTICE<<"TextureObjectSet::deleteAllTextureObjects()"<<std::endl;
 
+    if (_pendingOrphanedTextureObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
@@ -619,6 +621,7 @@ void TextureObjectSet::discardAllTextureObjects()
     _tail = 0;
 
     _pendingOrphanedTextureObjects.clear();
+    _pendingOrphanedTextureObjectsSize.exchange(0);
     _orphanedTextureObjects.clear();
 
     unsigned int numDeleted = _numOfTextureObjects;
@@ -633,6 +636,7 @@ void TextureObjectSet::discardAllTextureObjects()
 void TextureObjectSet::flushAllDeletedTextureObjects()
 {
     // OSG_NOTICE<<"TextureObjectSet::flushAllDeletedTextureObjects()"<<std::endl;
+    if (_pendingOrphanedTextureObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
@@ -666,6 +670,7 @@ void TextureObjectSet::discardAllDeletedTextureObjects()
     // OSG_NOTICE<<"TextureObjectSet::discardAllDeletedTextureObjects()"<<std::endl;
 
     // clean up the pending orphans.
+    if (_pendingOrphanedTextureObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
@@ -691,6 +696,7 @@ void TextureObjectSet::flushDeletedTextureObjects(double /*currentTime*/, double
 {
     // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..)"<<std::endl;
 
+    if (_pendingOrphanedTextureObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"TextureObjectSet::flushDeletedTextureObjects(..) handling orphans"<<std::endl;
@@ -756,6 +762,7 @@ void TextureObjectSet::flushDeletedTextureObjects(double /*currentTime*/, double
 
 bool TextureObjectSet::makeSpace(unsigned int& size)
 {
+    if (_pendingOrphanedTextureObjectsSize != 0)
     {
         OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex);
         // OSG_NOTICE<<"TextureObjectSet::TextureObjectSet::makeSpace(..) handling orphans"<<std::endl;
@@ -980,6 +987,7 @@ void TextureObjectSet::orphan(Texture::TextureObject* to)
     // list.  This double buffered approach to handling orphaned TO's is used
     // to avoid having to mutex the process of appling active TO's.
     _pendingOrphanedTextureObjects.push_back(to);
+    ++_pendingOrphanedTextureObjectsSize;
 
 #if 0
     OSG_NOTICE<<"TextureObjectSet::orphan("<<to<<")  _pendingOrphanedTextureObjects.size()="<<_pendingOrphanedTextureObjects.size()<<std::endl;

--- a/src/osg/Texture.cpp
+++ b/src/osg/Texture.cpp
@@ -1289,6 +1289,11 @@ bool TextureObjectManager::checkConsistency() const
     return true;
 }
 
+void TextureObjectManager::reportStats(unsigned frameNumber, Stats& stats) const
+{
+    stats.setAttribute(frameNumber, "TextureObjectManager" + std::to_string(_contextID), static_cast<double>(_textureSetMap.size()));
+}
+
 osg::ref_ptr<Texture::TextureObject> Texture::generateTextureObject(const Texture* texture, unsigned int contextID, GLenum target)
 {
     return osg::get<TextureObjectManager>(contextID)->generateTextureObject(texture, target);

--- a/src/osg/VertexArrayState.cpp
+++ b/src/osg/VertexArrayState.cpp
@@ -14,6 +14,7 @@
 #include <osg/VertexArrayState>
 #include <osg/State>
 #include <osg/ContextData>
+#include <osg/Stats>
 
 using namespace osg;
 
@@ -102,10 +103,20 @@ public:
         _vertexArrayStateList.push_back(vas);
     }
 
+    void reportStats(unsigned frameNumber, Stats& stats) const override
+    {
+        const std::size_t size = [&](){
+            const OpenThreads::ScopedLock<OpenThreads::Mutex> lock(_mutex_vertexArrayStateList);
+            return _vertexArrayStateList.size();
+        }();
+
+        stats.setAttribute(frameNumber, "VertexArrayStateManager" + std::to_string(_contextID), static_cast<double>(size));
+    }
+
 protected:
 
     typedef std::list< osg::ref_ptr<VertexArrayState> > VertexArrayStateList;
-    OpenThreads::Mutex _mutex_vertexArrayStateList;
+    mutable OpenThreads::Mutex _mutex_vertexArrayStateList;
     VertexArrayStateList _vertexArrayStateList;
 };
 


### PR DESCRIPTION
`TextureObjectManager` and `GLBufferObjectManager` store sets of objects per profile. When object is deleted it's removed from the set but the manager keeps storing the set. Over time with more profiles being used there are more sets and a lot of them are empty. Still there is overhead on flushing deleted objects because all sets are checked every frame. With this change after objects are deleted from every set we also erase it if it's empty. Overall this increases performance because less number of sets have to be checked. Fixes https://gitlab.com/OpenMW/openmw/-/issues/8918.

The performace test is done with openmw using [cross_cell_border_with_pause.zip](https://github.com/user-attachments/files/24626772/cross_cell_border_with_pause.zip) Lua mod. It moves player across many cells via rectangular spiral and then back to the original position and rotation with pauses at start and finish. Following scripts are used to start openmw and collect profiles:

<details>

<summary>Benchmark scripts</summary>

`scripts/run/cross_cell_border_with_pause.sh`

```bash
#!/bin/bash -ex

export SRC="$(pwd)"

if [[ "${1}" ]]; then
    cd "${1}"
fi

export BENCH_ID=$(date +%Y-%m-%dT%H-%M-%S)

if [[ "${3}" ]]; then
    BENCH_ID="${3}.${BENCH_ID:?}"
fi

export BENCH_DIR="/home/elsid/dev/openmw/generated/benchmarks/${BENCH_ID:?}"

mkdir -p "${BENCH_DIR:?}"

cp "/home/elsid/.config/openmw/settings.cfg" "${BENCH_DIR:?}/"
cp "/home/elsid/.config/openmw/openmw.cfg" "${BENCH_DIR:?}/"
cp -r "/home/elsid/dev/openmw/scripts/mods/cross_cell_border_with_pause" "${BENCH_DIR:?}/"

export ASAN_OPTIONS=halt_on_error=1:strict_string_checks=1:detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1
export TSAN_OPTIONS=second_deadlock_stack=1
export UBSAN_OPTIONS=print_stacktrace=1
export OPENMW_OSG_STATS_FILE="/tmp/openmw.stats.${BENCH_ID:?}.log"
export OPENMW_OSG_STATS_LIST="times;resource"

rm -f '/home/elsid/.config/openmw/openmw.log'

"${SRC:?}/scripts/other/perf.sh" &

PERF_SCRIPT_PID=$!

trap "pkill -P ${PERF_SCRIPT_PID:?}; kill -SIGKILL ${PERF_SCRIPT_PID:?}" SIGHUP SIGINT SIGTERM

/usr/bin/time -v \
    ./openmw \
        --skip-menu \
        --no-grab \
        --start "${2:-balmora}" \
        --script-run /home/elsid/dev/openmw/scripts/mods/cross_cell_border_with_pause/setup.mwscript \
        --data /home/elsid/dev/openmw/scripts/mods/cross_cell_border_with_pause \
        --content cross_cell_border_with_pause.omwscripts

cp '/home/elsid/.config/openmw/openmw.log' "${BENCH_DIR:?}/openmw.log"
cp "${OPENMW_OSG_STATS_FILE:?}" "${BENCH_DIR:?}/openmw.stats.log"

wait

cd "${SRC:?}"

scripts/other/report.sh
```

`scripts/other/perf.sh`

```bash
#!/bin/bash -ex

while true; do
    grep -F first_pause /home/elsid/.config/openmw/openmw.log && break || true
    sleep 1
done

sleep 1

timeout 1s perf record -p $(pidof openmw) --call-graph dwarf -o /tmp/perf.data.first.${BENCH_ID:?} &

FIRST_PERF_PID=$!

trap "kill -SIGKILL ${FIRST_PERF_PID:?}" SIGHUP SIGINT SIGTERM

while true; do
    grep -F second_pause /home/elsid/.config/openmw/openmw.log && break || true
    sleep 1
done

sleep 1

timeout 1s perf record -p $(pidof openmw) --call-graph dwarf -o /tmp/perf.data.second.${BENCH_ID:?} &

SECOND_PERF_PID=$!

trap "kill -SIGKILL ${FIRST_PERF_PID:?}; kill -SIGKILL ${SECOND_PERF_PID:?}" SIGHUP SIGINT SIGTERM

wait

cp /tmp/perf.data.first.${BENCH_ID:?} "${BENCH_DIR:?}/"
cp /tmp/perf.data.second.${BENCH_ID:?} "${BENCH_DIR:?}/"
```

`scripts/other/report.sh`

```bash
#!/bin/bash -ex

hotspot /tmp/perf.data.first.${BENCH_ID:?} &> /dev/null &
hotspot /tmp/perf.data.second.${BENCH_ID:?} &> /dev/null &
scripts/osg_stats.py --regexp_match --timeseries 'Frame duration|.*time taken' --moving_average_window 60 "/tmp/openmw.stats.${BENCH_ID:?}.log" &
scripts/osg_stats.py --regexp_match --stats 'Frame duration|.*time taken' "/tmp/openmw.stats.${BENCH_ID:?}.log"
```

</details>

With https://gitlab.com/elsid/openmw/-/commit/67480503285d4f5019e8cc5429dde82f3e8487d0 measured number of sets or other entities stored by each manager per frame:

<img width="1920" height="965" alt="managers_before_vs_after" src="https://github.com/user-attachments/assets/bdc4aef8-a866-402e-a3e6-249fbe70540a" />

<img width="1920" height="965" alt="texture_manager_before_vs_after" src="https://github.com/user-attachments/assets/35a9e258-5900-48dd-8bb8-743f9fbce945" />

Frame duration moving average with 60 frames window size:

<img width="1920" height="965" alt="frame_duration_before_vs_after" src="https://github.com/user-attachments/assets/db62dbdf-d555-4c75-a86a-8b60f21860da" />

A collection to store pending orphaned objects is replaced by `std::vector` because `std::list` only gives overhead there. Also a mutex lock to check `std::vector` emptiness before processing pending orphaned objects is replaced by atomic counting the number of items there. Since this check is performed every frame, potential consistency issues do not matter.

Perf profiles:

Before:

<img width="3840" height="2096" alt="perf_before" src="https://github.com/user-attachments/assets/435bea30-37e0-42ca-b06d-6c93a22bcf87" />

<img width="3840" height="2096" alt="perf_flush_before" src="https://github.com/user-attachments/assets/ac7d748e-77b7-401a-94c9-a5900341764b" />

With lock:

<img width="3840" height="2096" alt="perf_after_with_lock" src="https://github.com/user-attachments/assets/c72046b1-9c6b-4bb4-913f-d0735c4d0a7a" />

<img width="3840" height="2096" alt="perf_flush_after_with_lock" src="https://github.com/user-attachments/assets/c4875625-e829-45a8-8bdc-ae3e0b293080" />

With atomic:

<img width="3840" height="2096" alt="perf_after_with_atomic" src="https://github.com/user-attachments/assets/64e00d15-09cb-4a19-a921-0038b93d1591" />

<img width="3840" height="2096" alt="perf_flush_after_with_atomic" src="https://github.com/user-attachments/assets/3b9c6e1e-2771-49ea-9981-05846cebbf1d" />
