### PR TITLE
Fix -Wunused-parameter in GraphicsObjectManager

### DIFF
--- a/include/osg/GLObjects
+++ b/include/osg/GLObjects
@@ -68,7 +68,7 @@ class OSG_EXPORT GraphicsObjectManager : public osg::Referenced
         virtual void reportStats(std::ostream& /*out*/)  {}
         virtual void recomputeStats(std::ostream& /*out*/) const  {}
 
-        virtual void reportStats(unsigned frameNumber, Stats& stats) const {}
+        virtual void reportStats(unsigned /*frameNumber*/, Stats& /*stats*/) const {}
 
 
         /** Flush all deleted OpenGL objects within the specified availableTime.


### PR DESCRIPTION
Oops, missed this when my nitpick in #35 was addressed.
```
/home/capostrophic/openscenegraph/include/osg/GLObjects: In member function «virtual void osg::GraphicsObjectManager::reportStats(unsigned int, osg::Stats&) const»:
/home/capostrophic/openscenegraph/include/osg/GLObjects:71:43: предупреждение: неиспользуемый параметр «frameNumber» [-Wunused-parameter]
   71 |         virtual void reportStats(unsigned frameNumber, Stats& stats) const {}
      |                                  ~~~~~~~~~^~~~~~~~~~~
/home/capostrophic/openscenegraph/include/osg/GLObjects:71:63: предупреждение: неиспользуемый параметр «stats» [-Wunused-parameter]
   71 |         virtual void reportStats(unsigned frameNumber, Stats& stats) const {}
```