### PR TITLE
Add error for unsupported Android in Atomic.cpp

### DIFF
--- a/src/OpenThreads/common/Atomic.cpp
+++ b/src/OpenThreads/common/Atomic.cpp
@@ -25,6 +25,10 @@ namespace OpenThreads {
 
 #if defined(_OPENTHREADS_ATOMIC_USE_LIBRARY_ROUTINES)
 
+#if defined(__ANDROID__)
+#error Not supported.
+#endif
+
 // Non inline implementations for two special cases:
 // * win32
 // * i386 gcc


### PR DESCRIPTION
I'm not sure best approach here, 

I guess `#if defined(_OPENTHREADS_ATOMIC_USE_LIBRARY_ROUTINES) && !defined(__ANDROID__)` wasn't a good option?

[THIS](https://gitlab.com/modding-openmw/openmw-android-docker/-/blob/main/patches/osg/osgcombined.patch?ref_type=heads#L366) is the patch being removed in this commit.