### PR TITLE
Add support for GLES3 dynamic loading

### DIFF
--- a/src/osg/GLExtensions.cpp
+++ b/src/osg/GLExtensions.cpp
@@ -335,6 +335,8 @@ OSG_INIT_SINGLETON_PROXY(GLExtensionDisableStringInitializationProxy, osg::getGL
             static void *handle = dlopen("libGLESv1_CM.so", RTLD_NOW);
         #elif defined(OSG_GLES2_AVAILABLE)
             static void *handle = dlopen("libGLESv2.so", RTLD_NOW);
+        #elif defined(OSG_GLES3_AVAILABLE)
+            static void *handle = dlopen("libGLESv3.so", RTLD_NOW);
         #elif defined(OSG_GL1_AVAILABLE)
             static void *handle = dlopen("libGL.so", RTLD_NOW);
         #endif


### PR DESCRIPTION
Fix error with handle being undefined when using GLES3.

all other gles 3 code seems to be added from osg upstream except this,
as seen [here](https://github.com/openscenegraph/OpenSceneGraph/blob/2e4ae2ea94595995c1fc56860051410b0c0be605/src/osg/GLExtensions.cpp#L343).